### PR TITLE
175 test sample topology

### DIFF
--- a/src/default_dict.hpp
+++ b/src/default_dict.hpp
@@ -7,6 +7,7 @@
 #include <iostream>
 #include <unordered_map>
 #include <utility>
+#include "sugar.hpp"
 
 template <class Key, class T>
 class DefaultDict {

--- a/src/libsbn.cpp
+++ b/src/libsbn.cpp
@@ -115,13 +115,14 @@ size_t SBNInstance::SampleIndex(std::pair<size_t, size_t> range) const {
 
 // This function samples a tree by first sampling the rootsplit, and then
 // calling the recursive form of SampleTopology.
-Node::NodePtr SBNInstance::SampleTopology() const {
+Node::NodePtr SBNInstance::SampleTopology(bool rooted) const {
   // Start by sampling a rootsplit.
   size_t rootsplit_index =
       SampleIndex(std::pair<size_t, size_t>(0, rootsplits_.size()));
   const Bitset &rootsplit = rootsplits_.at(rootsplit_index);
   // The addition below turns the rootsplit into a subsplit.
-  auto topology = SampleTopology(rootsplit + ~rootsplit)->Deroot();
+  auto topology = rooted ? SampleTopology(rootsplit + ~rootsplit)
+                         : SampleTopology(rootsplit + ~rootsplit)->Deroot();
   topology->Polish();
   return topology;
 }

--- a/src/libsbn.hpp
+++ b/src/libsbn.hpp
@@ -374,7 +374,7 @@ TEST_CASE("libsbn") {
   // Count the frequencies of rooted trees in a file.
   size_t rooted_tree_count_from_file = 0;
   RootedIndexerRepresentationSizeDict counter_from_file(0);
-  for (const auto& indexer_representation : inst.MakeIndexerRepresentations()) {
+  for (const auto &indexer_representation : inst.MakeIndexerRepresentations()) {
     SBNMaps::IncrementRootedIndexerRepresentationSizeDict(counter_from_file,
                                                           indexer_representation);
     rooted_tree_count_from_file += indexer_representation.size();

--- a/src/libsbn.hpp
+++ b/src/libsbn.hpp
@@ -267,6 +267,19 @@ TEST_CASE("libsbn") {
   CHECK_EQ(inst.psp_indexer_.StringRepresentationOf(indexer_test_topology_2),
            correct_psp_representation_2);
 
+  // Rooted test
+  // Topology is ((((0,1),2),3),4);, or with internal nodes ((((0,1)5,2)6,3)7,4)8;
+  auto indexer_test_rooted_topology_1 =
+      Node::OfParentIdVector({5, 5, 6, 7, 8, 6, 7, 8});
+
+  std::cout << SBNMaps::RootedIndexerRepresentationOf(
+                   inst.indexer_, indexer_test_rooted_topology_1, 99999999)
+            << std::endl;
+  //  std::cout << inst.StringIndexerRepresentationOf(
+  //                   {SBNMaps::RootedIndexerRepresentationOf(
+  //                       inst.indexer_, indexer_test_rooted_topology_1, 99999999)})
+  //            << std::endl;
+
   // Test likelihood and gradient computation.
   inst.ReadNexusFile("data/DS1.subsampled_10.t");
   inst.ReadFastaFile("data/DS1.fasta");

--- a/src/libsbn.hpp
+++ b/src/libsbn.hpp
@@ -358,7 +358,7 @@ TEST_CASE("libsbn") {
   inst.TrainExpectationMaximization(0., 23);
   CheckVectorXdEquality(inst.CalculateSBNProbabilities(), expected_EM_0_23, 1e-12);
   
-  inst.ReadNewickFile("/Users/sjun2/libsbn/data/five_taxon.nwk");
+  inst.ReadNewickFile("data/five_taxon.nwk");
   inst.ProcessLoadedTrees();
   inst.TrainSimpleAverage();
 

--- a/src/libsbn.hpp
+++ b/src/libsbn.hpp
@@ -67,7 +67,7 @@ class SBNInstance {
   size_t SampleIndex(std::pair<size_t, size_t> range) const;
 
   // Sample a topology from the SBN.
-  Node::NodePtr SampleTopology() const;
+  Node::NodePtr SampleTopology(bool rooted = false) const;
 
   // Sample trees and store them internally
   void SampleTrees(size_t count);

--- a/src/libsbn.hpp
+++ b/src/libsbn.hpp
@@ -267,18 +267,15 @@ TEST_CASE("libsbn") {
   CHECK_EQ(inst.psp_indexer_.StringRepresentationOf(indexer_test_topology_2),
            correct_psp_representation_2);
 
-  // Rooted test
+  // Test of RootedIndexerRepresentationOf.
   // Topology is ((((0,1),2),3),4);, or with internal nodes ((((0,1)5,2)6,3)7,4)8;
   auto indexer_test_rooted_topology_1 =
       Node::OfParentIdVector({5, 5, 6, 7, 8, 6, 7, 8});
-
-  std::cout << SBNMaps::RootedIndexerRepresentationOf(
-                   inst.indexer_, indexer_test_rooted_topology_1, 99999999)
-            << std::endl;
-  //  std::cout << inst.StringIndexerRepresentationOf(
-  //                   {SBNMaps::RootedIndexerRepresentationOf(
-  //                       inst.indexer_, indexer_test_rooted_topology_1, 99999999)})
-  //            << std::endl;
+  auto correct_rooted_indexer_representation_1 = StringSet(
+      {"00001", "00001|11110|00010", "00010|11100|00100", "00100|11000|01000"});
+  CHECK_EQ(inst.StringIndexerRepresentationOf({SBNMaps::RootedIndexerRepresentationOf(
+               inst.indexer_, indexer_test_rooted_topology_1, 99999999)})[0],
+           correct_rooted_indexer_representation_1);
 
   // Test likelihood and gradient computation.
   inst.ReadNexusFile("data/DS1.subsampled_10.t");

--- a/src/libsbn.hpp
+++ b/src/libsbn.hpp
@@ -277,6 +277,14 @@ TEST_CASE("libsbn") {
   CHECK_EQ(inst.StringIndexerRepresentationOf({SBNMaps::RootedIndexerRepresentationOf(
                inst.indexer_, indexer_test_rooted_topology_1, out_of_sample_index)})[0],
            correct_rooted_indexer_representation_1);
+  // Topology is (((0,1),2),(3,4));, or with internal nodes (((0,1)5,2)6,(3,4)7)8;
+  auto indexer_test_rooted_topology_2 =
+      Node::OfParentIdVector({5, 5, 6, 7, 7, 6, 8, 8});
+  auto correct_rooted_indexer_representation_2 = StringSet(
+      {"00011", "11100|00011|00001", "00011|11100|00100", "00100|11000|01000"});
+  CHECK_EQ(inst.StringIndexerRepresentationOf({SBNMaps::RootedIndexerRepresentationOf(
+               inst.indexer_, indexer_test_rooted_topology_2, out_of_sample_index)})[0],
+           correct_rooted_indexer_representation_2);
 
   // Test likelihood and gradient computation.
   inst.ReadNexusFile("data/DS1.subsampled_10.t");

--- a/src/libsbn.hpp
+++ b/src/libsbn.hpp
@@ -370,7 +370,7 @@ TEST_CASE("libsbn") {
     n_trees_from_file += indexer_representation.size();
   }
 
-  size_t n_sampled_trees = 100000;
+  size_t n_sampled_trees = 1000000;
   RootedIndexerRepresentationSizeDict counter_from_sampling(0);
   for (size_t sample_idx = 0; sample_idx < n_sampled_trees; ++sample_idx) {
     const auto topology = inst.SampleTopology(true);
@@ -382,7 +382,7 @@ TEST_CASE("libsbn") {
   for (auto it = counter_from_file.begin(); it != counter_from_file.end(); ++it) {
     double observed = (double)counter_from_sampling.at(it->first)/n_sampled_trees;
     double expected = (double)counter_from_file.at(it->first)/n_trees_from_file;
-    CHECK_LT(fabs(observed - expected), 1e-2);
+    CHECK_LT(fabs(observed - expected), 5e-3);
   }
 
 }

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -304,6 +304,19 @@ void Node::PCSSPreOrder(PCSSFun f) const {
       });
 }
 
+void Node::RootedPCSSPreOrder(RootedPCSSFun f) const {
+  this->TriplePreOrderBifurcating([&f](const Node* node, const Node* sister,
+                                       const Node* parent) {
+    if (!node->IsLeaf()) {
+      Assert(node->Children().size() == 2,
+             "RootedPCSSPreOrder expects a bifurcating tree.");
+      auto child0 = node->Children()[0].get();
+      auto child1 = node->Children()[1].get();
+      f(sister, node, child0, child1);
+    }
+  });
+}
+
 // This function assigns ids to the nodes of the topology: the leaves get
 // their fixed ids (which we assume are contiguously numbered from 0 through
 // the leaf count -1) and the rest get ordered according to a postorder

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -305,16 +305,16 @@ void Node::PCSSPreOrder(PCSSFun f) const {
 }
 
 void Node::RootedPCSSPreOrder(RootedPCSSFun f) const {
-  this->TriplePreOrderBifurcating([&f](const Node* node, const Node* sister,
-                                       const Node* parent) {
-    if (!node->IsLeaf()) {
-      Assert(node->Children().size() == 2,
-             "RootedPCSSPreOrder expects a bifurcating tree.");
-      auto child0 = node->Children()[0].get();
-      auto child1 = node->Children()[1].get();
-      f(sister, node, child0, child1);
-    }
-  });
+  this->TriplePreOrderBifurcating(
+      [&f](const Node* node, const Node* sister, const Node* parent) {
+        if (!node->IsLeaf()) {
+          Assert(node->Children().size() == 2,
+                 "RootedPCSSPreOrder expects a bifurcating tree.");
+          auto child0 = node->Children()[0].get();
+          auto child1 = node->Children()[1].get();
+          f(sister, node, child0, child1);
+        }
+      });
 }
 
 // This function assigns ids to the nodes of the topology: the leaves get

--- a/src/node.hpp
+++ b/src/node.hpp
@@ -63,9 +63,11 @@ class Node {
   // the entire tree. There's nothing else we can do without rerooting the tree.
   // It's not too hard to exclude the undesired bits with a conditional tree
   // traversal. See IndexerRepresentationOfTopology for an example.
-  typedef std::function<void(const Node*, bool, const Node*, bool, const Node*, bool,
-                             const Node*, bool, const Node*)>
-      PCSSFun;
+  using PCSSFun = std::function<void(const Node*, bool, const Node*, bool, const Node*,
+                                     bool, const Node*, bool, const Node*)>;
+  // The rooted version just gives: sister clade, the focal clade, child 0, and child 1.
+  using RootedPCSSFun =
+      std::function<void(const Node*, const Node*, const Node*, const Node*)>;
 
  public:
   explicit Node(uint32_t leaf_id, Bitset leaves);
@@ -120,6 +122,7 @@ class Node {
   // See the typedef of PCSSFun to understand the argument type to this
   // function.
   void PCSSPreOrder(PCSSFun f) const;
+  void RootedPCSSPreOrder(RootedPCSSFun f) const;
 
   // This function prepares the id_ and leaves_ member variables as described at
   // the start of this document. It returns a map that maps the tags to their

--- a/src/node.hpp
+++ b/src/node.hpp
@@ -119,8 +119,8 @@ class Node {
   void BinaryIdPreOrder(const std::function<void(int, int, int)> f) const;
   void BinaryIdPostOrder(const std::function<void(int, int, int)> f) const;
 
-  // See the typedef of PCSSFun to understand the argument type to these
-  // functions.
+  // See the typedef of PCSSFun and RootedPCSSFun to understand the argument type to
+  // these functions.
   void PCSSPreOrder(PCSSFun f) const;
   void RootedPCSSPreOrder(RootedPCSSFun f) const;
 

--- a/src/node.hpp
+++ b/src/node.hpp
@@ -65,7 +65,7 @@ class Node {
   // traversal. See IndexerRepresentationOfTopology for an example.
   using PCSSFun = std::function<void(const Node*, bool, const Node*, bool, const Node*,
                                      bool, const Node*, bool, const Node*)>;
-  // The rooted version just gives: sister clade, the focal clade, child 0, and child 1.
+  // The rooted version just uses: sister clade, the focal clade, child 0, and child 1.
   using RootedPCSSFun =
       std::function<void(const Node*, const Node*, const Node*, const Node*)>;
 
@@ -119,8 +119,8 @@ class Node {
   void BinaryIdPreOrder(const std::function<void(int, int, int)> f) const;
   void BinaryIdPostOrder(const std::function<void(int, int, int)> f) const;
 
-  // See the typedef of PCSSFun to understand the argument type to this
-  // function.
+  // See the typedef of PCSSFun to understand the argument type to these
+  // functions.
   void PCSSPreOrder(PCSSFun f) const;
   void RootedPCSSPreOrder(RootedPCSSFun f) const;
 

--- a/src/noodle.cpp
+++ b/src/noodle.cpp
@@ -24,4 +24,27 @@ int main() {
 
   std::chrono::duration<double> duration = now() - t_start;
   std::cout << "time: " << duration.count() << " seconds\n";
+
+  // Playing with counting.
+  SBNInstance inst("charlie");
+  inst.ReadNewickFile("data/five_taxon.nwk");
+  // inst.ReadNewickFile("data/DS1.100_topologies.nwk");
+  inst.ProcessLoadedTrees();
+  inst.TrainSimpleAverage();
+
+  RootedIndexerRepresentationSizeDict counter_from_file(0);
+  for (const auto& indexer_representation : inst.MakeIndexerRepresentations()) {
+    SBNMaps::IncrementRootedIndexerRepresentationSizeDict(counter_from_file,
+                                                          indexer_representation);
+  }
+  std::cout << counter_from_file << std::endl;
+
+  RootedIndexerRepresentationSizeDict counter_from_sampling(0);
+  for (size_t sample_idx = 0; sample_idx < 10000; ++sample_idx) {
+    const auto topology = inst.SampleTopology(true);
+    SBNMaps::IncrementRootedIndexerRepresentationSizeDict(
+        counter_from_sampling,
+        SBNMaps::RootedIndexerRepresentationOf(inst.indexer_, topology, 99999999));
+  }
+  std::cout << counter_from_sampling << std::endl;
 }

--- a/src/noodle.cpp
+++ b/src/noodle.cpp
@@ -24,27 +24,4 @@ int main() {
 
   std::chrono::duration<double> duration = now() - t_start;
   std::cout << "time: " << duration.count() << " seconds\n";
-
-  // Playing with counting.
-  SBNInstance inst("charlie");
-  inst.ReadNewickFile("data/five_taxon.nwk");
-  // inst.ReadNewickFile("data/DS1.100_topologies.nwk");
-  inst.ProcessLoadedTrees();
-  inst.TrainSimpleAverage();
-
-  RootedIndexerRepresentationSizeDict counter_from_file(0);
-  for (const auto& indexer_representation : inst.MakeIndexerRepresentations()) {
-    SBNMaps::IncrementRootedIndexerRepresentationSizeDict(counter_from_file,
-                                                          indexer_representation);
-  }
-  std::cout << counter_from_file << std::endl;
-
-  RootedIndexerRepresentationSizeDict counter_from_sampling(0);
-  for (size_t sample_idx = 0; sample_idx < 10000; ++sample_idx) {
-    const auto topology = inst.SampleTopology(true);
-    SBNMaps::IncrementRootedIndexerRepresentationSizeDict(
-        counter_from_sampling,
-        SBNMaps::RootedIndexerRepresentationOf(inst.indexer_, topology, 99999999));
-  }
-  std::cout << counter_from_sampling << std::endl;
 }

--- a/src/sbn_maps.cpp
+++ b/src/sbn_maps.cpp
@@ -228,6 +228,25 @@ SizeVector SBNMaps::RootedIndexerRepresentationOf(const BitsetSizeMap& indexer,
   return result;
 }
 
+void SBNMaps::IncrementRootedIndexerRepresentationSizeDict(
+    RootedIndexerRepresentationSizeDict& dict,
+    SizeVector rooted_indexer_representation) {
+  Assert(rooted_indexer_representation.size() > 1,
+         "Rooted indexer representation is too small in "
+         "IncrementRootedIndexerRepresentationSizeDict!");
+  std::sort(rooted_indexer_representation.begin() + 1,
+            rooted_indexer_representation.end());
+  dict.increment(rooted_indexer_representation, 1);
+}
+
+void SBNMaps::IncrementRootedIndexerRepresentationSizeDict(
+    RootedIndexerRepresentationSizeDict& dict,
+    const IndexerRepresentation& indexer_representation) {
+  for (const auto& rooted_indexer_representation : indexer_representation) {
+    IncrementRootedIndexerRepresentationSizeDict(dict, rooted_indexer_representation);
+  }
+}
+
 StringPCSSMap SBNMaps::StringPCSSMapOf(PCSSDict d) {
   StringPCSSMap d_str;
   for (const auto& iter : d) {

--- a/src/sbn_maps.cpp
+++ b/src/sbn_maps.cpp
@@ -114,11 +114,10 @@ Bitset Rootsplit(const Node* rooted_topology) {
 
 // Make a PCSS bitset from a collection of Nodes and their directions. If direction is
 // true, then the bits get flipped.
-Bitset PCSSBitsetOf(const size_t leaf_count, const Node* sister_node,
-                    bool sister_direction, const Node* focal_node,
-                    bool focal_direction,  //
-                    const Node* child0_node,
-                    bool child0_direction,  //
+Bitset PCSSBitsetOf(const size_t leaf_count,  //
+                    const Node* sister_node, bool sister_direction,
+                    const Node* focal_node, bool focal_direction,
+                    const Node* child0_node, bool child0_direction,
                     const Node* child1_node, bool child1_direction) {
   Bitset bitset(3 * leaf_count, false);
   bitset.CopyFrom(sister_node->Leaves(), 0, sister_direction);
@@ -153,10 +152,8 @@ IndexerRepresentation SBNMaps::IndexerRepresentationOf(const BitsetSizeMap& inde
   // Now we append the PCSSs.
   topology->PCSSPreOrder([&indexer, &default_index, &leaf_count, &result, &topology](
                              const Node* sister_node, bool sister_direction,
-                             const Node* focal_node,
-                             bool focal_direction,  //
-                             const Node* child0_node,
-                             bool child0_direction,  //
+                             const Node* focal_node, bool focal_direction,
+                             const Node* child0_node, bool child0_direction,
                              const Node* child1_node, bool child1_direction,
                              const Node* virtual_root_clade) {
     const auto bitset = PCSSBitsetOf(leaf_count, sister_node, sister_direction,

--- a/src/sbn_maps.cpp
+++ b/src/sbn_maps.cpp
@@ -103,9 +103,11 @@ SizeVector SBNMaps::SplitIndicesOf(const BitsetSizeMap& indexer,
   return split_result;
 }
 
-Bitset Rootsplit(const Node* topology) {
-  Assert(topology->Children().size() == 2, "Rootsplit expects a bifurcating tree.");
-  Bitset subsplit = topology->Children()[0]->Leaves();
+// Return the rootsplit of a rooted bifurcating topology.
+Bitset Rootsplit(const Node* rooted_topology) {
+  Assert(rooted_topology->Children().size() == 2,
+         "Rootsplit expects a bifurcating tree.");
+  Bitset subsplit = rooted_topology->Children()[0]->Leaves();
   subsplit.Minorize();
   return subsplit;
 }

--- a/src/sbn_maps.hpp
+++ b/src/sbn_maps.hpp
@@ -25,6 +25,7 @@ using IndexerRepresentationCounter =
     std::vector<std::pair<IndexerRepresentation, uint32_t>>;
 using PCSSDict = std::unordered_map<Bitset, DefaultDict<Bitset, size_t>>;
 using PCSSIndexVector = std::vector<size_t>;
+using RootedIndexerRepresentationSizeDict = DefaultDict<SizeVector, size_t>;
 
 using StringSizePairMap = std::unordered_map<std::string, std::pair<size_t, size_t>>;
 using SizeStringMap = std::unordered_map<size_t, std::string>;
@@ -74,10 +75,32 @@ IndexerRepresentationCounter IndexerRepresentationCounterOf(
 SizeVector RootedIndexerRepresentationOf(const BitsetSizeMap& indexer,
                                          const Node::NodePtr& topology,
                                          const size_t default_index);
+// For counting standardized (i.e. PCSS index sorted) rooted indexer representations.
+void IncrementRootedIndexerRepresentationSizeDict(
+    RootedIndexerRepresentationSizeDict& dict,
+    const SizeVector rooted_indexer_representation);
+// Apply the above to every rooting in the indexer representation.
+void IncrementRootedIndexerRepresentationSizeDict(
+    RootedIndexerRepresentationSizeDict& dict,
+    const IndexerRepresentation& indexer_representation);
+
 // Make a string version of a PCSSDict.
 StringPCSSMap StringPCSSMapOf(PCSSDict d);
 
 }  // namespace SBNMaps
+
+namespace std {
+template <>
+struct hash<SizeVector> {
+  size_t operator()(const SizeVector& values) const {
+    int hash = values[0];
+    for (size_t i = 1; i < values.size(); i++) {
+      hash ^= values[i] + 0x9e3779b9 + (hash << 6) + (hash >> 2);
+    }
+    return hash;
+  }
+};
+}  // namespace std
 
 #ifdef DOCTEST_LIBRARY_INCLUDED
 

--- a/src/sbn_maps.hpp
+++ b/src/sbn_maps.hpp
@@ -89,7 +89,7 @@ StringPCSSMap StringPCSSMapOf(PCSSDict d);
 
 }  // namespace SBNMaps
 
-// Hash for vectors of unsigned ints.
+// Hash for vectors of size_t.
 // https://www.boost.org/doc/libs/1_35_0/doc/html/boost/hash_combine_id241013.html
 namespace std {
 template <>

--- a/src/sbn_maps.hpp
+++ b/src/sbn_maps.hpp
@@ -65,9 +65,9 @@ IndexerRepresentation IndexerRepresentationOf(const BitsetSizeMap& indexer,
 IndexerRepresentationCounter IndexerRepresentationCounterOf(
     const BitsetSizeMap& indexer, const Node::TopologyCounter& topology_counter,
     const size_t default_index);
-IndexerRepresentation RootedIndexerRepresentationOf(const BitsetSizeMap& indexer,
-                                                    const Node::NodePtr& topology,
-                                                    const size_t default_index);
+SizeVector RootedIndexerRepresentationOf(const BitsetSizeMap& indexer,
+                                         const Node::NodePtr& topology,
+                                         const size_t default_index);
 // Make a string version of a PCSSDict.
 StringPCSSMap StringPCSSMapOf(PCSSDict d);
 

--- a/src/sbn_maps.hpp
+++ b/src/sbn_maps.hpp
@@ -89,6 +89,8 @@ StringPCSSMap StringPCSSMapOf(PCSSDict d);
 
 }  // namespace SBNMaps
 
+// Hash for vectors of unsigned ints.
+// https://www.boost.org/doc/libs/1_35_0/doc/html/boost/hash_combine_id241013.html
 namespace std {
 template <>
 struct hash<SizeVector> {

--- a/src/sbn_maps.hpp
+++ b/src/sbn_maps.hpp
@@ -65,6 +65,9 @@ IndexerRepresentation IndexerRepresentationOf(const BitsetSizeMap& indexer,
 IndexerRepresentationCounter IndexerRepresentationCounterOf(
     const BitsetSizeMap& indexer, const Node::TopologyCounter& topology_counter,
     const size_t default_index);
+IndexerRepresentation RootedIndexerRepresentationOf(const BitsetSizeMap& indexer,
+                                                    const Node::NodePtr& topology,
+                                                    const size_t default_index);
 // Make a string version of a PCSSDict.
 StringPCSSMap StringPCSSMapOf(PCSSDict d);
 

--- a/src/sbn_maps.hpp
+++ b/src/sbn_maps.hpp
@@ -1,5 +1,8 @@
 // Copyright 2019 libsbn project contributors.
 // libsbn is free software under the GPLv3; see LICENSE file for details.
+//
+// A collection of functions to handle the subsplit support and to turn trees into
+// indexer representations.
 
 #ifndef SRC_SBN_MAPS_HPP_
 #define SRC_SBN_MAPS_HPP_
@@ -65,6 +68,9 @@ IndexerRepresentation IndexerRepresentationOf(const BitsetSizeMap& indexer,
 IndexerRepresentationCounter IndexerRepresentationCounterOf(
     const BitsetSizeMap& indexer, const Node::TopologyCounter& topology_counter,
     const size_t default_index);
+// A rooted indexer representation is the indexer representation of a given rooted tree.
+// That is, the first entry is the rootsplit for that rooting, and after that come the
+// PCSS indices.
 SizeVector RootedIndexerRepresentationOf(const BitsetSizeMap& indexer,
                                          const Node::NodePtr& topology,
                                          const size_t default_index);


### PR DESCRIPTION
Implemented a simple Monte Carlo test to sample topology with @matsen .
1. Load five_taxon.nwk, count the total number of rooted topologies (there are 28 of them so 1/28 for each topology)
2. Sample 100,000 rooted trees, estimate the probability of seeing each rooted topology and compare to the expected value of 1/28.
3. Using the tolerance of 5e-3.
