### PR TITLE
181 scale em

### DIFF
--- a/src/numerical_utils.hpp
+++ b/src/numerical_utils.hpp
@@ -5,7 +5,8 @@
 #define SRC_NUMERICAL_UTILS_HPP_
 
 #include <fenv.h>
-#include <limits.h>
+#include <limits>
+#include <string>
 
 #include "eigen_sugar.hpp"
 #include "sugar.hpp"
@@ -18,6 +19,10 @@ inline double LOG_EPS = log(EPS);
 // DOUBLE_MINIMUM defines de facto minimum value for double to deal with
 // potential overflow resulting from summing of large number of log
 // probabilities.
+// Note: using std::numeric_limits<double>::lowest() may result in numerical
+// instability, especially if other operations are to be performed using it.
+// This is why we are using a value that is slightly larger to denote
+// the lowest double value that we will consider.
 inline double DOUBLE_MINIMUM = std::numeric_limits<double>::lowest()*1e-10;
 
 namespace NumericalUtils {

--- a/src/numerical_utils.hpp
+++ b/src/numerical_utils.hpp
@@ -6,7 +6,6 @@
 
 #include <fenv.h>
 #include <limits>
-#include <string>
 
 #include "eigen_sugar.hpp"
 #include "sugar.hpp"

--- a/src/numerical_utils.hpp
+++ b/src/numerical_utils.hpp
@@ -15,6 +15,10 @@ constexpr double DOUBLE_NEG_INF = -std::numeric_limits<double>::infinity();
 constexpr double EPS = std::numeric_limits<double>::epsilon();
 // It turns out that log isn't constexpr for silly reasons, so we use inline instead.
 inline double LOG_EPS = log(EPS);
+// DOUBLE_MINIMUM defines de facto minimum value for double to deal with
+// potential overflow resulting from summing of large number of log
+// probabilities.
+inline double DOUBLE_MINIMUM = std::numeric_limits<double>::lowest()*1e-10;
 
 namespace NumericalUtils {
 

--- a/src/numerical_utils.hpp
+++ b/src/numerical_utils.hpp
@@ -16,6 +16,7 @@ constexpr double DOUBLE_NEG_INF = -std::numeric_limits<double>::infinity();
 constexpr double EPS = std::numeric_limits<double>::epsilon();
 // It turns out that log isn't constexpr for silly reasons, so we use inline instead.
 inline double LOG_EPS = log(EPS);
+constexpr double ERR_TOLERANCE = 1e-10;
 // DOUBLE_MINIMUM defines de facto minimum value for double to deal with
 // potential overflow resulting from summing of large number of log
 // probabilities.
@@ -23,7 +24,7 @@ inline double LOG_EPS = log(EPS);
 // instability, especially if other operations are to be performed using it.
 // This is why we are using a value that is slightly larger to denote
 // the lowest double value that we will consider.
-inline double DOUBLE_MINIMUM = std::numeric_limits<double>::lowest()*1e-10;
+inline double DOUBLE_MINIMUM = std::numeric_limits<double>::lowest()*ERR_TOLERANCE;
 
 namespace NumericalUtils {
 

--- a/src/numerical_utils.hpp
+++ b/src/numerical_utils.hpp
@@ -89,6 +89,13 @@ TEST_CASE("NumericalUtils") {
     sum += log_vec(i);
   }
   CHECK_LT(fabs(sum - 1), 1e-5);
+
+  // Here we use volatile to avoid GCC optimizing away the variable.
+  volatile double d = 4.;
+  d /= 0.;
+  auto fp_description = NumericalUtils::DescribeFloatingPointEnvironmentExceptions();
+  CHECK_EQ(*fp_description,
+           "The following floating point problems have been encountered: FE_DIVBYZERO");
 }
 #endif  // DOCTEST_LIBRARY_INCLUDED
 

--- a/src/numerical_utils.hpp
+++ b/src/numerical_utils.hpp
@@ -25,6 +25,9 @@ constexpr double ERR_TOLERANCE = 1e-10;
 // the lowest double value that we will consider.
 inline double DOUBLE_MINIMUM = std::numeric_limits<double>::lowest()*ERR_TOLERANCE;
 
+constexpr auto FE_OVER_AND_UNDER_FLOW_EXCEPT = FE_OVERFLOW | FE_UNDERFLOW;
+
+
 namespace NumericalUtils {
 
 // Return log(exp(x) + exp(y)).

--- a/src/pylibsbn.cpp
+++ b/src/pylibsbn.cpp
@@ -59,6 +59,9 @@ PYBIND11_MODULE(libsbn, m) {
            "Constructor from a vector of trees and a vector of taxon names.")
       .def("erase", &TreeCollection::Erase,
            "Erase the specified range from the current tree collection.")
+      .def("drop_first", &TreeCollection::DropFirst,
+           "Drop the first ``fraction`` trees from the tree collection.",
+           py::arg("fraction"))
       .def("newick", &TreeCollection::Newick,
            "Get the current set of trees as a big Newick string.")
       .def_readwrite("trees", &TreeCollection::trees_);

--- a/src/sbn_probability.cpp
+++ b/src/sbn_probability.cpp
@@ -2,6 +2,7 @@
 // libsbn is free software under the GPLv3; see LICENSE file for details.
 
 #include "sbn_probability.hpp"
+#include <algorithm>
 #include <cmath>
 #include <iostream>
 #include <numeric>
@@ -282,6 +283,10 @@ EigenVectorXd SBNProbability::ExpectationMaximization(
     progress_bar.display();
   }  // End of EM loop.
   progress_bar.done();
+  auto finite_count = std::count_if(sbn_parameters.begin(), sbn_parameters.end(),
+                                    [](double d) { return std::isfinite(d); });
+  std::cout << finite_count << " / " << sbn_parameters.size()
+            << " of sbn_parameters are finite after training.\n";
   NumericalUtils::ReportFloatingPointEnvironmentExceptions("|After EM|");
   return score_history;
 }

--- a/src/sbn_probability.cpp
+++ b/src/sbn_probability.cpp
@@ -276,6 +276,7 @@ EigenVectorXd SBNProbability::ExpectationMaximization(
       if (fabs(scaled_score_improvement) < score_epsilon) {
         std::cout << "EM converged according to normalized score improvement < "
                   << score_epsilon << "." << std::endl;
+        score_history.resize(em_idx + 1);
         break;
       }
     }

--- a/src/sbn_probability.cpp
+++ b/src/sbn_probability.cpp
@@ -302,10 +302,6 @@ EigenVectorXd SBNProbability::ExpectationMaximization(
     progress_bar.display();
   }  // End of EM loop.
   progress_bar.done();
-  auto finite_count = std::count_if(sbn_parameters.begin(), sbn_parameters.end(),
-                                    [](double d) { return std::isfinite(d); });
-  std::cout << finite_count << " / " << sbn_parameters.size()
-            << " of sbn_parameters are finite after training.\n";
   NumericalUtils::ReportFloatingPointEnvironmentExceptions("|After EM|");
   return score_history;
 }

--- a/src/tree_collection.cpp
+++ b/src/tree_collection.cpp
@@ -58,12 +58,20 @@ bool TreeCollection::operator==(const TreeCollection &other) const {
 
 void TreeCollection::Erase(size_t begin_idx, size_t end_idx) {
   if (begin_idx > end_idx || end_idx > TreeCount()) {
-    Failwith("Illegal arguments to Tree_Collection.Erase");
+    Failwith("Illegal arguments to Tree_Collection.Erase.");
   }
   // else:
   using difference_type = Tree::TreeVector::difference_type;
   trees_.erase(trees_.begin() + static_cast<difference_type>(begin_idx),
                trees_.begin() + static_cast<difference_type>(end_idx));
+}
+
+void TreeCollection::DropFirst(double fraction) {
+  Assert(fraction >= 0. && fraction <= 1.,
+         "Illegal argument to TreeCollection.DropFirst.");
+  size_t tree_count = TreeCount();
+  size_t end_idx = static_cast<size_t>(fraction * static_cast<double>(tree_count));
+  Erase(0, end_idx);
 }
 
 std::string TreeCollection::Newick() const {

--- a/src/tree_collection.hpp
+++ b/src/tree_collection.hpp
@@ -29,6 +29,8 @@ class TreeCollection {
 
   // Remove trees from begin_idx to just before end_idx.
   void Erase(size_t begin_idx, size_t end_idx);
+  // Drop the first fraction trees from the collection.
+  void DropFirst(double fraction);
 
   std::string Newick() const;
 
@@ -57,6 +59,10 @@ TEST_CASE("TreeCollection") {
        {"(0_1,2_1,(1_1,3_1)3_2)3_4;", 1},
        {"(0_1,(1_1,(2_1,3_1)3_2)3_3)3_4;", 1}});
   CHECK_EQ(counted, counted_correct);
+  collection.DropFirst(0.25);
+  CHECK_EQ(collection.TreeCount(), 3);
+  collection.DropFirst(1.);
+  CHECK_EQ(collection.TreeCount(), 0);
 }
 #endif  // DOCTEST_LIBRARY_INCLUDED
 


### PR DESCRIPTION
- Removed if statement that checks for LOG_EPS for probability of a rooted topology, which was the cause that led to the EM algorithm failing to update the parameters for large trees (all rooted trees had probability lower than LOG_EPS so nothing was being updated).
- Introduced ERR_TOLERANCE = 1e-10. This value is used rather than EPS to check for potential reversion of EM score in the subsequent iterations . EPS represents the smallest representable value close to 0 and it turned out to be too strict, resulting in failed assertions when the difference in score from current iteration to the previous iteration was something like -1e-16.
- Overflow/underflow problem stemming from summing the log probabilities is handled by checking for floating point environment and assigning DOUBLE_MINIMUM when it occurs, which is defined as the lowest representable double times ERR_TOLERANCE=1e-10. This tolerance value is needed as the code may continue to perform operations on DOUBLE_MINIMUM, for example via LogSum/LogAdd. When using lowest double, it resulted in further floating point errors leading to numerical instability.

