### PR TITLE
248 redundant likelihood operations

### DIFF
--- a/src/gp_doctest.cpp
+++ b/src/gp_doctest.cpp
@@ -66,6 +66,9 @@ TEST_CASE("GPInstance: straightforward classical likelihood calculation") {
   inst.PopulatePLVs();
   inst.PrintDAG();
   inst.ComputeLikelihoods();
+  
+  EigenVectorXd realized_log_likelihoods = inst.GetEngine()->GetLogLikelihoods();
+  CheckVectorXdEquality(-84.77961943, realized_log_likelihoods, 1e-6);
 
   CHECK_LT(fabs(engine->GetLogMarginalLikelihood() - -84.77961943), 1e-6);
 }

--- a/src/gp_instance.cpp
+++ b/src/gp_instance.cpp
@@ -120,6 +120,7 @@ void GPInstance::EstimateBranchLengths(double tol, size_t max_iter) {
   std::chrono::duration<double> warmup_duration = now() - t_start;
   t_start = now();
   std::cout << "Computing initial likelihood\n";
+  ProcessOperations(marginal_lik_operations);
   double current_marginal_log_lik = GetEngine()->GetLogMarginalLikelihood();
   std::chrono::duration<double> initial_likelihood_duration = now() - t_start;
   t_start = now();

--- a/src/gp_instance.cpp
+++ b/src/gp_instance.cpp
@@ -109,7 +109,6 @@ void GPInstance::EstimateBranchLengths(double tol, size_t max_iter) {
   auto now = std::chrono::high_resolution_clock::now;
   auto t_start = now();
   std::cout << "Begin branch optimization\n";
-  GPOperationVector compute_likelihoods_operations = dag_.ComputeLikelihoods();
   GPOperationVector branch_optimization_operations = dag_.BranchLengthOptimization();
   GPOperationVector marginal_lik_operations = dag_.MarginalLikelihood();
 
@@ -119,7 +118,6 @@ void GPInstance::EstimateBranchLengths(double tol, size_t max_iter) {
   std::chrono::duration<double> warmup_duration = now() - t_start;
   t_start = now();
   std::cout << "Computing initial likelihood\n";
-  ProcessOperations(compute_likelihoods_operations);
   double current_marginal_log_lik = GetEngine()->GetLogMarginalLikelihood();
   std::chrono::duration<double> initial_likelihood_duration = now() - t_start;
   t_start = now();


### PR DESCRIPTION
- Removed compute likelihood operations when estimating branch lengths. Marginal likelihood operations are sufficient.
- Adding a test to check for correctness to GPInstance::ComputeLikelihoods.