### PR TITLE
Simple Average SBN training for rooted trees

### DIFF
--- a/src/doctest_constants.hpp
+++ b/src/doctest_constants.hpp
@@ -1,0 +1,13 @@
+// Copyright 2019-2020 libsbn project contributors.
+// libsbn is free software under the GPLv3; see LICENSE file for details.
+
+#ifndef SRC_DOCTEST_CONSTANTS_HPP_
+#define SRC_DOCTEST_CONSTANTS_HPP_
+
+#ifdef DOCTEST_LIBRARY_INCLUDED
+
+// Below we use 99999999 is the default value if a rootsplit or PCSP is missing.
+const size_t out_of_sample_index = 99999999;
+
+#endif  // DOCTEST_LIBRARY_INCLUDED
+#endif  // SRC_DOCTEST_CONSTANTS_HPP_

--- a/src/pylibsbn.cpp
+++ b/src/pylibsbn.cpp
@@ -170,6 +170,13 @@ PYBIND11_MODULE(libsbn, m) {
             Note that this tree count need not be the same as the number of threads (and is typically bigger).
            )raw";
 
+  const char process_loaded_trees_docstring[] = R"raw(
+          Process the trees currently stored in the instance.
+
+          Specifically, parse them and build the subsplit support and allocate (but do not train) the corresponding SBN
+          parameters.
+      )raw";
+
   // CLASS
   // RootedSBNInstance
   py::class_<PreRootedSBNInstance>(m, "PreRootedSBNInstance");
@@ -193,7 +200,6 @@ PYBIND11_MODULE(libsbn, m) {
            "Read a sequence alignment from a FASTA file.")
       .def("taxon_names", &RootedSBNInstance::TaxonNames,
            "Return a list of taxon names.")
-      // ** END DUPLICATED CODE BLOCK between this and UnrootedSBNInstance
 
       // ** Initialization and status
       .def("print_status", &RootedSBNInstance::PrintStatus,
@@ -201,6 +207,18 @@ PYBIND11_MODULE(libsbn, m) {
       .def("tree_count", &RootedSBNInstance::TreeCount,
            "Return the number of trees that are currently stored in the "
            "instance.")
+
+      // ** SBN-related items
+      .def("process_loaded_trees", &RootedSBNInstance::ProcessLoadedTrees,
+           process_loaded_trees_docstring)
+      .def("train_simple_average", &RootedSBNInstance::TrainSimpleAverage,
+           R"raw(
+           Train the SBN using the "simple average" estimator.
+
+           For rooted trees this training is simpler than in the unrooted case:
+           we simply take the normalized frequency of PCSPs.
+           )raw")
+      // ** END DUPLICATED CODE BLOCK between this and UnrootedSBNInstance
 
       // ** Phylogenetic likelihood
       .def("log_likelihoods", &RootedSBNInstance::LogLikelihoods,
@@ -243,7 +261,6 @@ PYBIND11_MODULE(libsbn, m) {
            "Read a sequence alignment from a FASTA file.")
       .def("taxon_names", &UnrootedSBNInstance::TaxonNames,
            "Return a list of taxon names.")
-      // ** END DUPLICATED CODE BLOCK between this and RootedSBNInstance
 
       // ** Initialization and status
       .def("print_status", &UnrootedSBNInstance::PrintStatus,
@@ -253,11 +270,8 @@ PYBIND11_MODULE(libsbn, m) {
            "instance.")
 
       // ** SBN-related items
-      .def("process_loaded_trees", &UnrootedSBNInstance::ProcessLoadedTrees, R"raw(
-          Process the trees currently stored in the instance.
-
-          Specifically, parse them and build the indexers and the ``sbn_parameters`` vector.
-      )raw")
+      .def("process_loaded_trees", &UnrootedSBNInstance::ProcessLoadedTrees,
+           process_loaded_trees_docstring)
       .def("train_simple_average", &UnrootedSBNInstance::TrainSimpleAverage,
            R"raw(
            Train the SBN using the "simple average" estimator.
@@ -265,6 +279,8 @@ PYBIND11_MODULE(libsbn, m) {
            This is described in the "Maximum Lower Bound Estimates" section of the 2018
            NeurIPS paper, and is later referred to as the "SBN-SA" estimator.
            )raw")
+      // ** END DUPLICATED CODE BLOCK between this and RootedSBNInstance
+
       .def("train_expectation_maximization",
            &UnrootedSBNInstance::TrainExpectationMaximization,
            R"raw(

--- a/src/rooted_sbn_instance.cpp
+++ b/src/rooted_sbn_instance.cpp
@@ -3,6 +3,26 @@
 
 #include "rooted_sbn_instance.hpp"
 
+StringSet RootedSBNInstance::StringIndexerRepresentationOf(
+    const RootedIndexerRepresentation &indexer_representation) const {
+  return RootedSBNMaps::StringIndexerRepresentationOf(
+      sbn_support_.StringReversedIndexer(), indexer_representation);
+}
+
+StringSet RootedSBNInstance::StringIndexerRepresentationOf(
+    const Node::NodePtr &topology, size_t out_of_sample_index) const {
+  return StringIndexerRepresentationOf(
+      sbn_support_.IndexerRepresentationOf(topology, out_of_sample_index));
+}
+
+std::vector<double> RootedSBNInstance::LogLikelihoods() {
+  return GetEngine()->LogLikelihoods(tree_collection_, phylo_model_params_, rescaling_);
+}
+
+std::vector<RootedPhyloGradient> RootedSBNInstance::PhyloGradients() {
+  return GetEngine()->Gradients(tree_collection_, phylo_model_params_, rescaling_);
+}
+
 void RootedSBNInstance::ReadNewickFile(std::string fname) {
   Driver driver;
   tree_collection_ =
@@ -19,10 +39,3 @@ void RootedSBNInstance::ReadNexusFile(std::string fname) {
   tree_collection_.InitializeParameters();
 }
 
-std::vector<double> RootedSBNInstance::LogLikelihoods() {
-  return GetEngine()->LogLikelihoods(tree_collection_, phylo_model_params_, rescaling_);
-}
-
-std::vector<RootedPhyloGradient> RootedSBNInstance::PhyloGradients() {
-  return GetEngine()->Gradients(tree_collection_, phylo_model_params_, rescaling_);
-}

--- a/src/rooted_sbn_support.hpp
+++ b/src/rooted_sbn_support.hpp
@@ -17,9 +17,32 @@ class RootedSBNSupport : public SBNSupport {
                                     RootedSBNMaps::PCSPCounterOf(topologies));
   }
 
+  RootedIndexerRepresentationCounter IndexerRepresentationCounterOf(
+      const Node::TopologyCounter &topology_counter, const size_t out_of_sample_index) {
+    return RootedSBNMaps::IndexerRepresentationCounterOf(indexer_, topology_counter,
+                                                         out_of_sample_index);
+  }
+
+  RootedIndexerRepresentationCounter IndexerRepresentationCounterOf(
+      const Node::TopologyCounter &topology_counter) {
+    return IndexerRepresentationCounterOf(topology_counter, GPCSPCount());
+  }
+
+  RootedIndexerRepresentation IndexerRepresentationOf(
+      const Node::NodePtr &topology, const size_t out_of_sample_index) const {
+    return RootedSBNMaps::IndexerRepresentationOf(indexer_, topology,
+                                                  out_of_sample_index);
+  }
+
+  RootedIndexerRepresentation IndexerRepresentationOf(
+      const Node::NodePtr &topology) const {
+    return IndexerRepresentationOf(topology, GPCSPCount());
+  }
+
   static BitsetSizeDict RootsplitCounterOf(const Node::TopologyCounter &topologies) {
     return RootedSBNMaps::RootsplitCounterOf(topologies);
   }
+
   static PCSPDict PCSPCounterOf(const Node::TopologyCounter &topologies) {
     return RootedSBNMaps::PCSPCounterOf(topologies);
   }

--- a/src/sbn_maps.cpp
+++ b/src/sbn_maps.cpp
@@ -254,6 +254,17 @@ UnrootedIndexerRepresentationCounter UnrootedSBNMaps::IndexerRepresentationCount
   return counter;
 }
 
+StringSetVector UnrootedSBNMaps::StringIndexerRepresentationOf(
+    const StringVector& reversed_indexer,
+    const UnrootedIndexerRepresentation& indexer_representation) {
+  StringSetVector string_sets;
+  for (const auto& rooted_representation : indexer_representation) {
+    string_sets.push_back(RootedSBNMaps::StringIndexerRepresentationOf(
+        reversed_indexer, rooted_representation));
+  }
+  return string_sets;
+}
+
 BitsetSizeDict RootedSBNMaps::RootsplitCounterOf(
     const Node::TopologyCounter& topologies) {
   BitsetSizeDict rootsplit_counter(0);
@@ -280,9 +291,9 @@ PCSPDict RootedSBNMaps::PCSPCounterOf(const Node::TopologyCounter& topologies) {
   return pcsp_dict;
 }
 
-SizeVector RootedSBNMaps::RootedIndexerRepresentationOf(const BitsetSizeMap& indexer,
-                                                        const Node::NodePtr& topology,
-                                                        const size_t default_index) {
+SizeVector RootedSBNMaps::IndexerRepresentationOf(const BitsetSizeMap& indexer,
+                                                  const Node::NodePtr& topology,
+                                                  const size_t default_index) {
   const auto leaf_count = topology->LeafCount();
   SizeVector result;
   // Start with the rootsplit.
@@ -299,9 +310,32 @@ SizeVector RootedSBNMaps::RootedIndexerRepresentationOf(const BitsetSizeMap& ind
   return result;
 }
 
+StringSet RootedSBNMaps::StringIndexerRepresentationOf(
+    const StringVector& reversed_indexer,
+    const RootedIndexerRepresentation& indexer_representation) {
+  StringSet string_set;
+  for (const auto index : indexer_representation) {
+    SafeInsert(string_set, reversed_indexer.at(index));
+  }
+  return string_set;
+}
+
+RootedIndexerRepresentationCounter RootedSBNMaps::IndexerRepresentationCounterOf(
+    const BitsetSizeMap& indexer, const Node::TopologyCounter& topology_counter,
+    const size_t default_index) {
+  RootedIndexerRepresentationCounter counter;
+  counter.reserve(topology_counter.size());
+  for (const auto& [topology, topology_count] : topology_counter) {
+    counter.push_back(
+        {RootedSBNMaps::IndexerRepresentationOf(indexer, topology, default_index),
+         topology_count});
+  }
+  return counter;
+}
+
 void RootedSBNMaps::IncrementRootedIndexerRepresentationSizeDict(
     RootedIndexerRepresentationSizeDict& dict,
-    SizeVector rooted_indexer_representation) {
+    RootedIndexerRepresentation rooted_indexer_representation) {
   Assert(rooted_indexer_representation.size() > 1,
          "Rooted indexer representation is too small in "
          "IncrementRootedIndexerRepresentationSizeDict!");

--- a/src/sbn_maps.hpp
+++ b/src/sbn_maps.hpp
@@ -66,11 +66,19 @@ PCSPDict PCSPCounterOf(const Node::TopologyCounter& topologies);
 // `default_index`.
 UnrootedIndexerRepresentation IndexerRepresentationOf(const BitsetSizeMap& indexer,
                                                       const Node::NodePtr& topology,
-                                                      const size_t default_index);
+                                                      size_t default_index);
 // Turn a TopologyCounter into an IndexerRepresentationCounter.
 UnrootedIndexerRepresentationCounter IndexerRepresentationCounterOf(
     const BitsetSizeMap& indexer, const Node::TopologyCounter& topology_counter,
-    const size_t default_index);
+    size_t default_index);
+
+// Define a "reversed indexer" to be a vector with ith entry being the string version of
+// the ith GPCSP. This function takes such a vector and an unrooted indexer
+// representation and makes a vector of StringSets, such that the jth entry is the
+// string version of the indexer representation of the jth rooting.
+StringSetVector StringIndexerRepresentationOf(
+    const StringVector& reversed_indexer,
+    const UnrootedIndexerRepresentation& indexer_representation);
 
 }  // namespace UnrootedSBNMaps
 
@@ -82,13 +90,25 @@ PCSPDict PCSPCounterOf(const Node::TopologyCounter& topologies);
 // A rooted indexer representation is the indexer representation of a given rooted tree.
 // That is, the first entry is the rootsplit for that rooting, and after that come the
 // PCSP indices.
-RootedIndexerRepresentation RootedIndexerRepresentationOf(const BitsetSizeMap& indexer,
-                                                          const Node::NodePtr& topology,
-                                                          const size_t default_index);
+RootedIndexerRepresentation IndexerRepresentationOf(const BitsetSizeMap& indexer,
+                                                    const Node::NodePtr& topology,
+                                                    size_t default_index);
+// Turn a TopologyCounter into an IndexerRepresentationCounter.
+RootedIndexerRepresentationCounter IndexerRepresentationCounterOf(
+    const BitsetSizeMap& indexer, const Node::TopologyCounter& topology_counter,
+    size_t default_index);
+
+// Define a "reversed indexer" to be a vector with ith entry being the string version of
+// the ith GPCSP. This function takes such a vector and a rooted indexer representation
+// and makes a StringSet of the indexer representation.
+StringSet StringIndexerRepresentationOf(
+    const StringVector& reversed_indexer,
+    const RootedIndexerRepresentation& indexer_representation);
+
 // For counting standardized (i.e. PCSP index sorted) rooted indexer representations.
 void IncrementRootedIndexerRepresentationSizeDict(
     RootedIndexerRepresentationSizeDict& dict,
-    const RootedIndexerRepresentation rooted_indexer_representation);
+    RootedIndexerRepresentation rooted_indexer_representation);
 // Apply the above to every rooting in the unrooted indexer representation.
 void IncrementRootedIndexerRepresentationSizeDict(
     RootedIndexerRepresentationSizeDict& dict,
@@ -115,6 +135,8 @@ struct hash<SizeVector> {
   size_t operator()(const SizeVector& values) const {
     int hash = values[0];
     for (size_t i = 1; i < values.size(); i++) {
+      // https://stackoverflow.com/a/58845898/467327
+      // NOLINTNEXTLINE(hicpp-signed-bitwise)
       hash ^= values[i] + 0x9e3779b9 + (hash << 6) + (hash >> 2);
     }
     return hash;

--- a/src/sbn_probability.cpp
+++ b/src/sbn_probability.cpp
@@ -157,6 +157,35 @@ void SetCounts(
 
 // Set the provided counts vector to be the log of the counts of the rootsplits and
 // PCSPs provided in the input.
+// Note code duplication with the override below for
+// UnrootedIndexerRepresentationCounter.
+// We could refactor with templates, but then this whole file would have to go in the
+// header.
+void SetLogCounts(
+    EigenVectorXdRef counts,
+    const RootedIndexerRepresentationCounter& indexer_representation_counter,
+    size_t rootsplit_count, const BitsetSizePairMap& parent_to_range) {
+  counts.fill(DOUBLE_NEG_INF);
+  for (const auto& [indexer_representation, int_topology_count] :
+       indexer_representation_counter) {
+    const auto log_topology_count = log(static_cast<double>(int_topology_count));
+    IncrementByInLog(counts, indexer_representation, log_topology_count);
+  }
+}
+
+// Note code duplication with the override below for
+// UnrootedIndexerRepresentationCounter.
+void SBNProbability::SimpleAverage(
+    EigenVectorXdRef sbn_parameters,
+    const RootedIndexerRepresentationCounter& indexer_representation_counter,
+    size_t rootsplit_count, const BitsetSizePairMap& parent_to_range) {
+  SetLogCounts(sbn_parameters, indexer_representation_counter, rootsplit_count,
+               parent_to_range);
+}
+
+// Set the provided counts vector to be the log of the counts of the rootsplits and
+// PCSPs provided in the input.
+// Note code duplication with the override above for RootedIndexerRepresentationCounter.
 void SetLogCounts(
     EigenVectorXdRef counts,
     const UnrootedIndexerRepresentationCounter& indexer_representation_counter,
@@ -169,6 +198,7 @@ void SetLogCounts(
   }
 }
 
+// Note code duplication with the override above for RootedIndexerRepresentationCounter.
 void SBNProbability::SimpleAverage(
     EigenVectorXdRef sbn_parameters,
     const UnrootedIndexerRepresentationCounter& indexer_representation_counter,

--- a/src/sbn_probability.hpp
+++ b/src/sbn_probability.hpp
@@ -21,6 +21,11 @@ void SimpleAverage(
     const UnrootedIndexerRepresentationCounter& indexer_representation_counter,
     size_t rootsplit_count, const BitsetSizePairMap& parent_to_range);
 
+void SimpleAverage(
+    EigenVectorXdRef sbn_parameters,
+    const RootedIndexerRepresentationCounter& indexer_representation_counter,
+    size_t rootsplit_count, const BitsetSizePairMap& parent_to_range);
+
 // The "SBN-EM" estimator described in the "Expectation Maximization" section of
 // the 2018 NeurIPS paper. Returns the sequence of scores (defined in the paper)
 // obtained by the EM iterations.
@@ -31,7 +36,7 @@ EigenVectorXd ExpectationMaximization(
     size_t max_iter, double score_epsilon);
 
 // Calculate the probability of an indexer_representation of a topology.
-double ProbabilityOf(EigenConstVectorXdRef,
+double ProbabilityOf(EigenConstVectorXdRef sbn_parameters,
                      const UnrootedIndexerRepresentation& indexer_representation);
 
 // Calculate the probabilities of a collection of indexer_representations.

--- a/src/sbn_support.cpp
+++ b/src/sbn_support.cpp
@@ -34,7 +34,7 @@ std::tuple<StringSizeMap, StringSizePairMap> SBNSupport::GetIndexers() const {
 // Get the indexer, but reversed and with bitsets appropriately converted to
 // strings.
 StringVector SBNSupport::StringReversedIndexer() const {
-  std::vector<std::string> reversed_indexer(indexer_.size());
+  StringVector reversed_indexer(indexer_.size());
   for (const auto& [key, idx] : indexer_) {
     if (idx < rootsplits_.size()) {
       reversed_indexer[idx] = key.ToString();
@@ -46,7 +46,7 @@ StringVector SBNSupport::StringReversedIndexer() const {
 }
 
 void SBNSupport::ProbabilityNormalizeSBNParametersInLog(
-    EigenVectorXdRef sbn_parameters) {
+    EigenVectorXdRef sbn_parameters) const {
   SBNProbability::ProbabilityNormalizeParamsInLog(sbn_parameters, rootsplits_.size(),
                                                   parent_to_range_);
 }

--- a/src/sbn_support.hpp
+++ b/src/sbn_support.hpp
@@ -58,7 +58,7 @@ class SBNSupport {
   // strings.
   StringVector StringReversedIndexer() const;
 
-  void ProbabilityNormalizeSBNParametersInLog(EigenVectorXdRef sbn_parameters);
+  void ProbabilityNormalizeSBNParametersInLog(EigenVectorXdRef sbn_parameters) const;
 
  protected:
   // A vector of the taxon names.

--- a/src/sugar.hpp
+++ b/src/sugar.hpp
@@ -33,6 +33,7 @@ using StringVector = std::vector<std::string>;
 using StringVectorVector = std::vector<StringVector>;
 using StringSet = std::unordered_set<std::string>;
 using StringSetVector = std::vector<StringSet>;
+using StringDoubleVector = std::vector<std::pair<std::string, double>>;
 using DoublePair = std::pair<double, double>;
 using SizePair = std::pair<size_t, size_t>;
 

--- a/src/unrooted_sbn_instance.cpp
+++ b/src/unrooted_sbn_instance.cpp
@@ -12,15 +12,6 @@
 
 // ** Building SBN-related items
 
-void UnrootedSBNInstance::TrainSimpleAverage() {
-  CheckTopologyCounter();
-  auto indexer_representation_counter =
-      sbn_support_.IndexerRepresentationCounterOf(topology_counter_);
-  SBNProbability::SimpleAverage(sbn_parameters_, indexer_representation_counter,
-                                sbn_support_.RootsplitCount(),
-                                sbn_support_.ParentToRange());
-}
-
 EigenVectorXd UnrootedSBNInstance::TrainExpectationMaximization(double alpha,
                                                                 size_t max_iter,
                                                                 double score_epsilon) {
@@ -84,17 +75,9 @@ DoubleVectorVector UnrootedSBNInstance::SplitLengths() const {
 }
 
 StringSetVector UnrootedSBNInstance::StringIndexerRepresentationOf(
-    UnrootedIndexerRepresentation indexer_representation) const {
-  auto reversed_indexer = sbn_support_.StringReversedIndexer();
-  StringSetVector string_sets;
-  for (const auto &rooted_representation : indexer_representation) {
-    StringSet string_set;
-    for (const auto index : rooted_representation) {
-      SafeInsert(string_set, reversed_indexer[index]);
-    }
-    string_sets.push_back(std::move(string_set));
-  }
-  return string_sets;
+    const UnrootedIndexerRepresentation &indexer_representation) const {
+  return UnrootedSBNMaps::StringIndexerRepresentationOf(
+      sbn_support_.StringReversedIndexer(), indexer_representation);
 }
 
 StringSetVector UnrootedSBNInstance::StringIndexerRepresentationOf(


### PR DESCRIPTION
## Description

Implementing Simple Average training for rooted trees.

Fixes #211


## Tests

Added a simple test for rooted training. #271 will allow us to make stronger tests.

## Checklist:

* [x] `clang-format` has been run
* [x] The code uses informative and accurate variable and function names
* [x] The functionality is factored out into functions and methods with logical interfaces
* [x] Comments are up to date, document intent, and there are no commented-out code blocks
* [x] Commenting and/or documentation is sufficient for others to be able to understand intent and implementation
* [x] Variables are named according to our conventions
* [x] `const` used where appropriate
* [x] The code uses modern C++ conventions, including range-for, `auto`, and structured bindings
* [x] TODOs have been eliminated from the code
