### PR TITLE
Make GPDAG use the same PCSP bitset convention as the rest of the code

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,7 +12,7 @@ Please describe the tests added to verify correct behavior.
 
 ## Checklist:
 
-* [ ] `clang-format` has been run
+* [ ] `make format` has been run
 * [ ] The code uses informative and accurate variable and function names
 * [ ] The functionality is factored out into functions and methods with logical interfaces
 * [ ] Comments are up to date, document intent, and there are no commented-out code blocks

--- a/src/bitset.cpp
+++ b/src/bitset.cpp
@@ -1,5 +1,8 @@
 // Copyright 2019-2020 libsbn project contributors.
 // libsbn is free software under the GPLv3; see LICENSE file for details.
+//
+// Note that the default constructor for std::vector<bool> is filled with false:
+// https://stackoverflow.com/a/22984114/467327
 
 #include "bitset.hpp"
 
@@ -115,15 +118,15 @@ size_t Bitset::Hash() const { return std::hash<std::vector<bool>>{}(value_); }
 
 std::string Bitset::ToString() const {
   std::string str;
-  for (size_t i = 0; i < value_.size(); ++i) {
-    str += (value_[i] ? '1' : '0');
+  for (const auto& bit : value_) {
+    str += (bit ? '1' : '0');
   }
   return str;
 }
 
 bool Bitset::All() const {
-  for (size_t i = 0; i < value_.size(); ++i) {
-    if (!value_[i]) {
+  for (const auto& bit : value_) {
+    if (!bit) {
       return false;
     }
   }
@@ -131,13 +134,15 @@ bool Bitset::All() const {
 }
 
 bool Bitset::Any() const {
-  for (size_t i = 0; i < value_.size(); ++i) {
-    if (value_[i]) {
+  for (const auto& bit : value_) {
+    if (bit) {
       return true;
     }
   }
   return false;
 }
+
+bool Bitset::IsSingleton() const { return SingletonOption().has_value(); }
 
 void Bitset::Minorize() {
   Assert(!(value_.empty()), "Can't Bitset::Minorize an empty bitset.");
@@ -220,28 +225,42 @@ std::string Bitset::ToStringChunked(size_t chunk_count) const {
 std::string Bitset::SubsplitToString() const { return ToStringChunked(2); }
 std::string Bitset::PCSPToString() const { return ToStringChunked(3); }
 
+size_t Bitset::SubsplitChunkSize() const {
+  Assert(size() % 2 == 0, "Size isn't 0 mod 2 in Bitset::SubsplitChunkSize.");
+  return size() / 2;
+}
+
+Bitset Bitset::SubsplitChunk(size_t i) const {
+  Assert(i < 2, "SubsplitChunk index too large.");
+  size_t chunk_size = SubsplitChunkSize();
+  std::vector<bool> new_value(value_.begin() + int32_t(i * chunk_size),
+                              value_.begin() + int32_t((i + 1) * chunk_size));
+  return Bitset(std::move(new_value));
+}
+
 size_t Bitset::PCSPChunkSize() const {
   Assert(size() % 3 == 0, "Size isn't 0 mod 3 in Bitset::PCSPChunkSize.");
   return size() / 3;
 }
 
 Bitset Bitset::PCSPChunk(size_t i) const {
+  Assert(i < 3, "PCSPChunk index too large.");
   size_t chunk_size = PCSPChunkSize();
   std::vector<bool> new_value(value_.begin() + int32_t(i * chunk_size),
                               value_.begin() + int32_t((i + 1) * chunk_size));
-  return Bitset(new_value);
+  return Bitset(std::move(new_value));
 }
 
 Bitset Bitset::PCSPParent() const {
   size_t chunk_size = PCSPChunkSize();
   std::vector<bool> new_value(value_.begin(), value_.begin() + int32_t(2 * chunk_size));
-  return Bitset(new_value);
+  return Bitset(std::move(new_value));
 }
 
 Bitset Bitset::PCSPWithoutParent() const {
   size_t chunk_size = PCSPChunkSize();
   std::vector<bool> new_value(value_.begin() + int32_t(chunk_size), value_.end());
-  return Bitset(new_value);
+  return Bitset(std::move(new_value));
 }
 
 Bitset Bitset::PCSPChildSubsplit() const {
@@ -253,7 +272,7 @@ Bitset Bitset::PCSPChildSubsplit() const {
     // things that are in A but not in B.
     new_value[i] = new_value[i] && !(new_value[i + chunk_size]);
   }
-  return Bitset(new_value);
+  return Bitset(std::move(new_value));
 }
 
 bool Bitset::PCSPIsValid() const {
@@ -303,4 +322,56 @@ Bitset Bitset::ChildSubsplit(const Bitset& parent_subsplit, const Bitset& child_
     result.set(i + taxon_count, child_half[i]);
   }
   return result;
+}
+
+Bitset Bitset::PCSPOfPair(const Bitset& parent_subsplit, const Bitset& child_subsplit,
+                          bool assert_validity) {
+  Assert(parent_subsplit.size() == child_subsplit.size(),
+         "Size mismatch in Bitset::PCSPOfPair.");
+  Assert(parent_subsplit.size() % 2 == 0,
+         "Bitset::PCSPOfPair requires an even-sized bitsets.");
+  size_t taxon_count = parent_subsplit.size() / 2;
+  Bitset child_0 = child_subsplit.SubsplitChunk(0);
+  Bitset child_1 = child_subsplit.SubsplitChunk(1);
+  if (assert_validity) {
+    AssertIsDisjointUnion(parent_subsplit.SubsplitChunk(1), child_0, child_1);
+  }
+  Bitset pcsp(3 * taxon_count);
+  pcsp.CopyFrom(parent_subsplit, 0, false);
+  pcsp.CopyFrom(std::min(child_0, child_1), 2 * taxon_count, false);
+  return pcsp;
+}
+
+void Bitset::AssertIsDisjointUnion(const Bitset& should_be_union, const Bitset& set_1,
+                                   const Bitset& set_2) {
+  Assert(should_be_union.size() == set_1.size(),
+         "AssertIsDisjointUnion: size mismatch.");
+  Assert(set_1.size() == set_2.size(), "AssertIsDisjointUnion: size mismatch.");
+  for (size_t i = 0; i < should_be_union.size(); i++) {
+    if (should_be_union[i]) {
+      Assert(set_1[i] || set_2[i], "AssertIsDisjointUnion: given set not the union.");
+      Assert(set_1[i] ^ set_2[i], "AssertIsDisjointUnion: given sets not disjoint.");
+    } else {
+      Assert(!(set_1[i] || set_2[i]),
+             "AssertIsDisjointUnion: given set not the union.");
+    }
+  }
+}
+
+Bitset Bitset::FakeSubsplit(const Bitset& nonzero_contents) {
+  Bitset fake(2 * nonzero_contents.size());
+  // Put the nonzero contents on the left of the fake subsplit.
+  fake.CopyFrom(nonzero_contents, 0, false);
+  return fake;
+}
+
+Bitset Bitset::FakeChildSubsplit(const Bitset& parent_subsplit) {
+  Assert(parent_subsplit.SplitChunk(0).Any() &&
+             parent_subsplit.SplitChunk(1).IsSingleton(),
+         "FakeChildSubsplit requires that the left-hand chunk of the subsplit be "
+         "non-empty and the right-hand chunk be a singleton.");
+
+  // Put the right-hand chunk of the subsplit as the nonzero contents of the fake
+  // subsplit.
+  return FakeSubsplit(parent_subsplit.SplitChunk(1));
 }

--- a/src/gp_dag_node.hpp
+++ b/src/gp_dag_node.hpp
@@ -1,13 +1,12 @@
 // Copyright 2019-2020 libsbn project contributors.
 // libsbn is free software under the GPLv3; see LICENSE file for details.
 //
-// A class for node in a directed acyclic graph for generalized pruning.
+// A node in a directed acyclic graph for generalized pruning.
+//
+// Each node represents a subsplit, which is stored as a bitset in `subsplit_`.
 
 #ifndef SRC_GP_DAG_NODE_HPP_
 #define SRC_GP_DAG_NODE_HPP_
-
-#include <string>
-#include <vector>
 
 #include "bitset.hpp"
 #include "sugar.hpp"

--- a/src/gp_instance.hpp
+++ b/src/gp_instance.hpp
@@ -36,12 +36,20 @@ class GPInstance {
   void ComputeLikelihoods();
   RootedTreeCollection GenerateCompleteRootedTreeCollection();
 
+  // #273: A lot of code duplication here with things in SBNInstance.
+  StringVector PrettyIndexer() const;
+  void ProbabilityNormalizeSBNParametersInLog(EigenVectorXdRef sbn_parameters) const;
+  EigenVectorXd NormalizedSBNParametersIncludingFakeSubsplits() const;
+  StringDoubleVector PrettyIndexedSBNParameters();
+  void SBNParametersToCSV(const std::string &file_path);
+
  private:
   std::string mmap_file_path_;
   Alignment alignment_;
   std::unique_ptr<GPEngine> engine_;
   RootedTreeCollection tree_collection_;
   GPDAG dag_;
+  static constexpr size_t plv_count_per_node_ = 6;
 
   // A vector that contains all of the SBN-related probabilities.
   EigenVectorXd sbn_parameters_;

--- a/src/pylibsbn.cpp
+++ b/src/pylibsbn.cpp
@@ -218,6 +218,8 @@ PYBIND11_MODULE(libsbn, m) {
            For rooted trees this training is simpler than in the unrooted case:
            we simply take the normalized frequency of PCSPs.
            )raw")
+      .def("sbn_parameters_to_csv", &RootedSBNInstance::SBNParametersToCSV,
+           R"raw(Write "pretty" formatted SBN parameters to a CSV.)raw")
       // ** END DUPLICATED CODE BLOCK between this and UnrootedSBNInstance
 
       // ** Phylogenetic likelihood
@@ -279,6 +281,8 @@ PYBIND11_MODULE(libsbn, m) {
            This is described in the "Maximum Lower Bound Estimates" section of the 2018
            NeurIPS paper, and is later referred to as the "SBN-SA" estimator.
            )raw")
+      .def("sbn_parameters_to_csv", &UnrootedSBNInstance::SBNParametersToCSV,
+           R"raw(Write "pretty" formatted SBN parameters to a CSV.)raw")
       // ** END DUPLICATED CODE BLOCK between this and RootedSBNInstance
 
       .def("train_expectation_maximization",
@@ -364,6 +368,8 @@ PYBIND11_MODULE(libsbn, m) {
            "Read trees from a Nexus file.")
       .def("read_fasta_file", &GPInstance::ReadFastaFile,
            "Read a sequence alignment from a FASTA file.")
+      .def("sbn_parameters_to_csv", &GPInstance::SBNParametersToCSV,
+           R"raw(Write "pretty" formatted SBN parameters to a CSV.)raw")
 
       // ** Estimation
       .def("make_engine", &GPInstance::MakeEngine, "Prepare for optimization.",


### PR DESCRIPTION
## Description

Make GPDAG use the same PCSP bitset convention as the rest of the code. Also offer CSV export.

Fixes issue #247


## Tests

New Bitset functionality is covered by unit tests. Everything else is a refactor.

## Checklist:

* [x] `clang-format` has been run
* [x] The code uses informative and accurate variable and function names
* [x] The functionality is factored out into functions and methods with logical interfaces
* [x] Comments are up to date, document intent, and there are no commented-out code blocks
* [x] Commenting and/or documentation is sufficient for others to be able to understand intent and implementation
* [x] Variables are named according to our conventions
* [x] `const` used where appropriate
* [x] The code uses modern C++ conventions, including range-for, `auto`, and structured bindings
* [x] TODOs have been eliminated from the code
