### PR TITLE
267 lifting restricting bitsets

### DIFF
--- a/src/bitset.cpp
+++ b/src/bitset.cpp
@@ -377,11 +377,11 @@ Bitset Bitset::FakeChildSubsplit(const Bitset& parent_subsplit) {
 }
 
 Bitset Remap(Bitset bitset, const SizeOptionVector& idx_table) {
-    Bitset result{idx_table.size(), false};
-    for (size_t i = 0; i < idx_table.size(); ++i) {
-		if (idx_table[i].has_value() && bitset[idx_table[i].value()]) {
-			result.set(i, true);
-		}
-	}
-	return result;
+  Bitset result{idx_table.size(), false};
+  for (size_t i = 0; i < idx_table.size(); ++i) {
+    if (idx_table[i].has_value() && bitset[idx_table[i].value()]) {
+      result.set(i, true);
+    }
+  }
+  return result;
 }

--- a/src/bitset.cpp
+++ b/src/bitset.cpp
@@ -375,3 +375,13 @@ Bitset Bitset::FakeChildSubsplit(const Bitset& parent_subsplit) {
   // subsplit.
   return FakeSubsplit(parent_subsplit.SplitChunk(1));
 }
+
+Bitset Remap(Bitset bitset, const SizeOptionVector& idx_map) {
+	Bitset result{idx_map.size(), false};
+	for (size_t i = 0; i < idx_map.size(); ++i) {
+		if (idx_map[i].has_value()) {
+			result.set(i, bitset[idx_map[i].value()]);
+		}
+	}
+	return result;
+}

--- a/src/bitset.cpp
+++ b/src/bitset.cpp
@@ -376,11 +376,11 @@ Bitset Bitset::FakeChildSubsplit(const Bitset& parent_subsplit) {
   return FakeSubsplit(parent_subsplit.SplitChunk(1));
 }
 
-Bitset Remap(Bitset bitset, const SizeOptionVector& idx_map) {
-	Bitset result{idx_map.size(), false};
-	for (size_t i = 0; i < idx_map.size(); ++i) {
-		if (idx_map[i].has_value()) {
-			result.set(i, bitset[idx_map[i].value()]);
+Bitset Remap(Bitset bitset, const SizeOptionVector& idx_table) {
+    Bitset result{idx_table.size(), false};
+    for (size_t i = 0; i < idx_table.size(); ++i) {
+		if (idx_table[i].has_value() && bitset[idx_table[i].value()]) {
+			result.set(i, true);
 		}
 	}
 	return result;

--- a/src/bitset.cpp
+++ b/src/bitset.cpp
@@ -377,7 +377,7 @@ Bitset Bitset::FakeChildSubsplit(const Bitset& parent_subsplit) {
 }
 
 Bitset Remap(Bitset bitset, const SizeOptionVector& idx_table) {
-  Bitset result{idx_table.size(), false};
+  Bitset result(idx_table.size(), false);
   for (size_t i = 0; i < idx_table.size(); ++i) {
     if (idx_table[i].has_value() && bitset[idx_table[i].value()]) {
       result.set(i, true);

--- a/src/bitset.hpp
+++ b/src/bitset.hpp
@@ -141,6 +141,12 @@ struct equal_to<Bitset> {
 };
 }  // namespace std
 
+// Returns a new Bitset with size equal to "idx_table"'s size. Bits in the result
+// will be taken from the "bitset" parameter, with ordering taken from "idx_table".
+// Values in "idx_table" represent indices within "bitset".
+// "False" will be placed at result's indices which has nullopt in the corresponding
+// element in "idx_table". 
+
 Bitset Remap(Bitset bitset, const SizeOptionVector& idx_table);
 
 #ifdef DOCTEST_LIBRARY_INCLUDED
@@ -257,7 +263,10 @@ TEST_CASE("Bitset") {
   CHECK_EQ(Bitset::FakeSubsplit(Bitset("010")), Bitset("010000"));
   CHECK_EQ(Bitset::FakeChildSubsplit(Bitset("100001")), Bitset("001000"));
   
-  CHECK_EQ(Remap(Bitset{"10101010101"}, {0,2,4,6,8,10}), Bitset{"111111"});
+  CHECK_EQ(Remap(Bitset{"10101010101"}, {0,2,4,6,8,10}), Bitset{"111111"}); // restrict
+  SizeOptionVector rotate120{6,7,8,0,1,2,3,4,5};
+  CHECK_EQ(Remap(Remap(Remap(Bitset{"110010100"}, rotate120), rotate120), rotate120), Bitset{"110010100"});
+  CHECK_EQ(Remap(Bitset{"11"}, {0,std::nullopt,1}), Bitset{"101"}); // lift
   
 }
 #endif  // DOCTEST_LIBRARY_INCLUDED

--- a/src/bitset.hpp
+++ b/src/bitset.hpp
@@ -263,10 +263,10 @@ TEST_CASE("Bitset") {
   CHECK_EQ(Bitset::FakeSubsplit(Bitset("010")), Bitset("010000"));
   CHECK_EQ(Bitset::FakeChildSubsplit(Bitset("100001")), Bitset("001000"));
   
-  CHECK_EQ(Remap(Bitset{"10101010101"}, {0,2,4,6,8,10}), Bitset{"111111"}); // restrict
+  CHECK_EQ(Remap(Bitset("10101010101"), {0,2,4,6,8,10}), Bitset("111111")); // restrict
   SizeOptionVector rotate120{6,7,8,0,1,2,3,4,5};
-  CHECK_EQ(Remap(Remap(Remap(Bitset{"110010100"}, rotate120), rotate120), rotate120), Bitset{"110010100"});
-  CHECK_EQ(Remap(Bitset{"11"}, {0,std::nullopt,1}), Bitset{"101"}); // lift
+  CHECK_EQ(Remap(Remap(Remap(Bitset("110010100"), rotate120), rotate120), rotate120), Bitset("110010100"));
+  CHECK_EQ(Remap(Bitset("11"), {0,std::nullopt,1}), Bitset("101")); // lift
   
 }
 #endif  // DOCTEST_LIBRARY_INCLUDED

--- a/src/bitset.hpp
+++ b/src/bitset.hpp
@@ -146,7 +146,7 @@ struct equal_to<Bitset> {
 // * If the `idx_table` entry is an integer i, then the value is the ith
 //   entry of `bitset`.
 // * If the entry is nullopt, then the value is False (i.e. zero).
-Bitset Remap(Bitset bitset, const SizeOptionVector& idx_table);
+Bitset Remap(Bitset bitset, const SizeOptionVector &idx_table);
 
 #ifdef DOCTEST_LIBRARY_INCLUDED
 TEST_CASE("Bitset") {
@@ -263,14 +263,13 @@ TEST_CASE("Bitset") {
   CHECK_EQ(Bitset::FakeChildSubsplit(Bitset("100001")), Bitset("001000"));
 
   // Restrict a bitset.
-  CHECK_EQ(Remap(Bitset("10101010101"), {0,2,4,6,8,10}), Bitset("111111"));
+  CHECK_EQ(Remap(Bitset("10101010101"), {0, 2, 4, 6, 8, 10}), Bitset("111111"));
   // If we apply this remap 3 times we should get back to where we started.
-  SizeOptionVector rotate120{6,7,8,0,1,2,3,4,5};
+  SizeOptionVector rotate120{6, 7, 8, 0, 1, 2, 3, 4, 5};
   auto to_rotate = Bitset("110010100");
   CHECK_EQ(Remap(Remap(Remap(to_rotate, rotate120), rotate120), rotate120), to_rotate);
   // "Lift" a bitset.
-  CHECK_EQ(Remap(Bitset("11"), {0,std::nullopt,1}), Bitset("101"));
-
+  CHECK_EQ(Remap(Bitset("11"), {0, std::nullopt, 1}), Bitset("101"));
 }
 #endif  // DOCTEST_LIBRARY_INCLUDED
 

--- a/src/bitset.hpp
+++ b/src/bitset.hpp
@@ -141,12 +141,11 @@ struct equal_to<Bitset> {
 };
 }  // namespace std
 
-// Returns a new Bitset with size equal to "idx_table"'s size. Bits in the result
-// will be taken from the "bitset" parameter, with ordering taken from "idx_table".
-// Values in "idx_table" represent indices within "bitset".
-// "False" will be placed at result's indices which has nullopt in the corresponding
-// element in "idx_table". 
-
+// Returns a new Bitset with size equal to `idx_table`'s size. Each entry
+// of the new bitset is determined as follows:
+// * If the `idx_table` entry is an integer i, then the value is the ith
+//   entry of `bitset`.
+// * If the entry is nullopt, then the value is False (i.e. zero).
 Bitset Remap(Bitset bitset, const SizeOptionVector& idx_table);
 
 #ifdef DOCTEST_LIBRARY_INCLUDED
@@ -262,12 +261,16 @@ TEST_CASE("Bitset") {
 
   CHECK_EQ(Bitset::FakeSubsplit(Bitset("010")), Bitset("010000"));
   CHECK_EQ(Bitset::FakeChildSubsplit(Bitset("100001")), Bitset("001000"));
-  
-  CHECK_EQ(Remap(Bitset("10101010101"), {0,2,4,6,8,10}), Bitset("111111")); // restrict
+
+  // Restrict a bitset.
+  CHECK_EQ(Remap(Bitset("10101010101"), {0,2,4,6,8,10}), Bitset("111111"));
+  // If we apply this remap 3 times we should get back to where we started.
   SizeOptionVector rotate120{6,7,8,0,1,2,3,4,5};
-  CHECK_EQ(Remap(Remap(Remap(Bitset("110010100"), rotate120), rotate120), rotate120), Bitset("110010100"));
-  CHECK_EQ(Remap(Bitset("11"), {0,std::nullopt,1}), Bitset("101")); // lift
-  
+  auto to_rotate = Bitset("110010100");
+  CHECK_EQ(Remap(Remap(Remap(to_rotate, rotate120), rotate120), rotate120), to_rotate);
+  // "Lift" a bitset.
+  CHECK_EQ(Remap(Bitset("11"), {0,std::nullopt,1}), Bitset("101"));
+
 }
 #endif  // DOCTEST_LIBRARY_INCLUDED
 

--- a/src/bitset.hpp
+++ b/src/bitset.hpp
@@ -10,6 +10,8 @@
 #include <string>
 #include <vector>
 
+#include "sugar.hpp"
+
 // This file started life as the RbBitSet class from RevBayes by Sebastian
 // Hoehna. In general, I'm trying to follow the interface of std::bitset, though
 // this class goes way beyond what std::bitset offers.
@@ -139,9 +141,7 @@ struct equal_to<Bitset> {
 };
 }  // namespace std
 
-using SizeOptionVector = std::vector<std::optional<size_t>>;
-
-Bitset Remap(Bitset bitset, const SizeOptionVector& idx_map);
+Bitset Remap(Bitset bitset, const SizeOptionVector& idx_table);
 
 #ifdef DOCTEST_LIBRARY_INCLUDED
 TEST_CASE("Bitset") {
@@ -256,6 +256,9 @@ TEST_CASE("Bitset") {
 
   CHECK_EQ(Bitset::FakeSubsplit(Bitset("010")), Bitset("010000"));
   CHECK_EQ(Bitset::FakeChildSubsplit(Bitset("100001")), Bitset("001000"));
+  
+  CHECK_EQ(Remap(Bitset{"10101010101"}, {0,2,4,6,8,10}), Bitset{"111111"});
+  
 }
 #endif  // DOCTEST_LIBRARY_INCLUDED
 

--- a/src/bitset.hpp
+++ b/src/bitset.hpp
@@ -139,6 +139,10 @@ struct equal_to<Bitset> {
 };
 }  // namespace std
 
+using SizeOptionVector = std::vector<std::optional<size_t>>;
+
+Bitset Remap(Bitset bitset, const SizeOptionVector& idx_map);
+
 #ifdef DOCTEST_LIBRARY_INCLUDED
 TEST_CASE("Bitset") {
   Bitset a("1100");

--- a/src/sugar.hpp
+++ b/src/sugar.hpp
@@ -37,6 +37,7 @@ using StringSetVector = std::vector<StringSet>;
 using StringDoubleVector = std::vector<std::pair<std::string, double>>;
 using DoublePair = std::pair<double, double>;
 using SizePair = std::pair<size_t, size_t>;
+using SizeOptionVector = std::vector<std::optional<size_t>>;
 
 inline uint32_t MaxLeafIDOfTag(Tag tag) { return UnpackFirstInt(tag); }
 inline uint32_t LeafCountOfTag(Tag tag) { return UnpackSecondInt(tag); }

--- a/vip/burrito.py
+++ b/vip/burrito.py
@@ -137,7 +137,9 @@ class Burrito:
         self.inst.resize_phylo_model_params()
         px_phylo_log_like = np.array(self.inst.log_likelihoods(), copy=False)
         return self.elbo_of_sample(
-            px_phylo_log_like, px_theta_sample, px_branch_representation,
+            px_phylo_log_like,
+            px_theta_sample,
+            px_branch_representation,
         )
 
     def elbo_of_sample(


### PR DESCRIPTION
## Description

Added the Remap function according to requirements in #267 

Closes #267 


## Tests

Tests for restricting, reordering and lifting bitsets


## Checklist:

* [x ] The code uses informative and accurate variable and function names
* [x ] The functionality is factored out into functions and methods with logical interfaces
* [x ] Comments are up to date, document intent, and there are no commented-out code blocks
* [x ] Commenting and/or documentation is sufficient for others to be able to understand intent and implementation
* [x] Entities are named according to our conventions
* [x ] `const` used where appropriate
* [x ] The code uses modern C++ conventions, including range-for, `auto`, and structured bindings
* [x] `make format` has been run
* [x] TODOs have been eliminated from the code
* [x] The corresponding issue number (e.g. `#278`) has been searched for in the code to find relevant notes
