### PR TITLE
Dropping subsplit prior from PreparePerPatternLogLikelihoodsForGPCSP

### DIFF
--- a/src/gp_engine.cpp
+++ b/src/gp_engine.cpp
@@ -96,7 +96,7 @@ void GPEngine::operator()(const GPOperations::Multiply& op) {
 
 void GPEngine::operator()(const GPOperations::Likelihood& op) {
   SetTransitionMatrixToHaveBranchLength(branch_lengths_(op.dest_));
-  PreparePerPatternLogLikelihoodsForGPCSP(op.dest_, op.parent_, op.child_);
+  PreparePerPatternLogLikelihoodsForGPCSP(op.parent_, op.child_);
   log_likelihoods_.row(op.dest_) = per_pattern_log_likelihoods_;
 }
 
@@ -174,7 +174,7 @@ EigenVectorXd GPEngine::GetPerGPCSPLogLikelihoods(size_t start, size_t length) c
 DoublePair GPEngine::LogLikelihoodAndDerivative(
     const GPOperations::OptimizeBranchLength& op) {
   SetTransitionAndDerivativeMatricesToHaveBranchLength(branch_lengths_(op.gpcsp_));
-  PreparePerPatternLogLikelihoodsForGPCSP(op.gpcsp_, op.rootward_, op.leafward_);
+  PreparePerPatternLogLikelihoodsForGPCSP(op.rootward_, op.leafward_);
   // The prior is expressed using the current value of q_.
   // The phylogenetic component of the likelihood is weighted with the number of times
   // we see the site patterns.
@@ -256,7 +256,7 @@ double GPEngine::LogRescalingFor(size_t plv_idx) {
 void GPEngine::BrentOptimization(const GPOperations::OptimizeBranchLength& op) {
   auto negative_log_likelihood = [this, &op](double log_branch_length) {
     SetTransitionMatrixToHaveBranchLength(exp(log_branch_length));
-    PreparePerPatternLogLikelihoodsForGPCSP(op.gpcsp_, op.rootward_, op.leafward_);
+    PreparePerPatternLogLikelihoodsForGPCSP(op.rootward_, op.leafward_);
     return -per_pattern_log_likelihoods_.dot(site_pattern_weights_);
   };
   double current_log_branch_length = log(branch_lengths_(op.gpcsp_));

--- a/src/gp_engine.cpp
+++ b/src/gp_engine.cpp
@@ -114,11 +114,9 @@ void GPEngine::operator()(const GPOperations::UpdateSBNProbabilities& op) {
   EigenVectorXd log_likelihoods = GetPerGPCSPLogLikelihoods(op.start_, range_length);
   EigenVectorXd log_prior = q_.segment(op.start_, range_length).array().log();
   EigenVectorXd unnormalized_posterior = log_likelihoods + log_prior;
-  std::cout << "upost: " << unnormalized_posterior << std::endl;
   const double log_norm = NumericalUtils::LogSum(unnormalized_posterior);
   unnormalized_posterior.array() -= log_norm;
   q_.segment(op.start_, range_length) = unnormalized_posterior.array().exp();
-  std::cout << "post: " << q_.segment(op.start_, range_length) << std::endl;
 }
 
 void GPEngine::operator()(const GPOperations::PrepForMarginalization& op) {

--- a/src/gp_engine.cpp
+++ b/src/gp_engine.cpp
@@ -118,6 +118,7 @@ void GPEngine::operator()(const GPOperations::UpdateSBNProbabilities& op) {
   const double log_norm = NumericalUtils::LogSum(unnormalized_posterior);
   unnormalized_posterior.array() -= log_norm;
   q_.segment(op.start_, range_length) = unnormalized_posterior.array().exp();
+  std::cout << "post: " << q_.segment(op.start_, range_length) << std::endl;
 }
 
 void GPEngine::operator()(const GPOperations::PrepForMarginalization& op) {

--- a/src/gp_engine.cpp
+++ b/src/gp_engine.cpp
@@ -114,6 +114,7 @@ void GPEngine::operator()(const GPOperations::UpdateSBNProbabilities& op) {
   EigenVectorXd log_likelihoods = GetPerGPCSPLogLikelihoods(op.start_, range_length);
   EigenVectorXd log_prior = q_.segment(op.start_, range_length).array().log();
   EigenVectorXd unnormalized_posterior = log_likelihoods + log_prior;
+  std::cout << "upost: " << unnormalized_posterior << std::endl;
   const double log_norm = NumericalUtils::LogSum(unnormalized_posterior);
   unnormalized_posterior.array() -= log_norm;
   q_.segment(op.start_, range_length) = unnormalized_posterior.array().exp();

--- a/src/gp_engine.hpp
+++ b/src/gp_engine.hpp
@@ -166,11 +166,9 @@ class GPEngine {
   }
 
   // This function is used to compute the marginal log likelihood over all trees that
-  // have GPCSP corresponding to gpcsp_idx as a parent-child subsplit. We assume that
-  // transition_matrix_ is as desired, and src1_idx and src2_idx are the two PLV indices
-  // on either side of the GPCSP. Multiplication by the SBN probability, q_[gpcsp_idx],
-  // is needed to properly account for the likelihood of the trees.
-  inline void PreparePerPatternLogLikelihoodsForGPCSP(size_t gpcsp_idx, size_t src1_idx,
+  // have a given PCSP. We assume that transition_matrix_ is as desired, and src1_idx
+  // and src2_idx are the two PLV indices on either side of the PCSP.
+  inline void PreparePerPatternLogLikelihoodsForGPCSP(size_t src1_idx,
                                                       size_t src2_idx) {
     per_pattern_log_likelihoods_ =
         (plvs_.at(src1_idx).transpose() * transition_matrix_ * plvs_.at(src2_idx))

--- a/src/gp_engine.hpp
+++ b/src/gp_engine.hpp
@@ -172,13 +172,12 @@ class GPEngine {
   // is needed to properly account for the likelihood of the trees.
   inline void PreparePerPatternLogLikelihoodsForGPCSP(size_t gpcsp_idx, size_t src1_idx,
                                                       size_t src2_idx) {
-    per_pattern_log_likelihoods_ = (q_[gpcsp_idx] * plvs_.at(src1_idx).transpose() *
-                                    transition_matrix_ * plvs_.at(src2_idx))
-                                       .diagonal()
-                                       .array()
-                                       .log() +
-                                   LogRescalingFor(src1_idx) +
-                                   LogRescalingFor(src2_idx);
+    per_pattern_log_likelihoods_ =
+        (plvs_.at(src1_idx).transpose() * transition_matrix_ * plvs_.at(src2_idx))
+            .diagonal()
+            .array()
+            .log() +
+        LogRescalingFor(src1_idx) + LogRescalingFor(src2_idx);
   }
 };
 

--- a/src/gp_instance.cpp
+++ b/src/gp_instance.cpp
@@ -182,12 +182,9 @@ void GPInstance::EstimateBranchLengths(double tol, size_t max_iter) {
 
 void GPInstance::EstimateSBNParameters() {
   std::cout << "Begin SBN parameter optimization\n";
-  GPOperationVector sbn_param_optimization_operations = dag_.OptimizeSBNParameters();
-
   ResetMarginalLikelihoodAndPopulatePLVs();
   ComputeLikelihoods();
-
-  ProcessOperations(sbn_param_optimization_operations);
+  ProcessOperations(dag_.OptimizeSBNParameters());
   sbn_parameters_ = engine_->GetSBNParameters();
 }
 

--- a/src/gp_operation.hpp
+++ b/src/gp_operation.hpp
@@ -99,11 +99,8 @@ struct Likelihood {
 
 // Finds the optimal `branch_length` for the likelihood of
 // `plv[rootward_]` and `P(branch_length) plv[leafward_]`,
-// * starting optimization at `branch_lengths[branch_length_]`,
-// * storing the PLV for `P(branch_length) plv[leafward_]` in `plv[dest_]` for the
-// optimal branch length
-// * storing log likelihood at `log_likelihoods[branch_length_]`
-// * storing optimal branch length at `branch_lengths[branch_length_]`
+// starting optimization at `branch_lengths[branch_length_]`, and
+// storing optimal branch length at `branch_lengths[branch_length_]`.
 struct OptimizeBranchLength {
   constexpr OptimizeBranchLength(size_t leafward, size_t rootward, size_t gpcsp)
       : leafward_{leafward}, rootward_{rootward}, gpcsp_{gpcsp} {}


### PR DESCRIPTION
## Description

Dropping subsplit prior from PreparePerPatternLogLikelihoodsForGPCSP. It was being applied twice: once there and once in GPOperations::UpdateSBNProbabilities, which was incorrect and was leading to very imbalanced posteriors for SBN probabilities.

Closes #297 


## Tests

No new tests. See #299, which shows that we do need more tests here.

## Checklist:

* [ ] The code uses informative and accurate variable and function names
* [ ] The functionality is factored out into functions and methods with logical interfaces
* [ ] Comments are up to date, document intent, and there are no commented-out code blocks
* [ ] Commenting and/or documentation is sufficient for others to be able to understand intent and implementation
* [ ] Entities are named according to our conventions
* [ ] `const` used where appropriate
* [ ] The code uses modern C++ conventions, including range-for, `auto`, and structured bindings
* [ ] `make format` has been run
* [ ] TODOs have been eliminated from the code
* [ ] The corresponding issue number (e.g. `#278`) has been searched for in the code to find relevant notes
