### PR TITLE
Implement notion of a "tidy" DAG traversal that respects how PLVs get dirtied by edge modification

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Also let's:
 * Prefer [variable names and simple coding practices](https://blog.codinghorror.com/coding-without-comments/) to code comments.
   If that means having long identifier names, that's fine!
   If you can't make the code use and operation inherently obvious, please write documentation.
-* TODO comments don't get merged into master. Rather, make an issue on GitHub.
+* TODO comments don't get merged into main. Rather, make an issue on GitHub.
 * Always use curly braces for the body of conditionals and loops, even if they are one line.
 
 The [C++ Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines) are the authority for how to write C++, and we will follow them.

--- a/SConstruct
+++ b/SConstruct
@@ -169,6 +169,7 @@ sources = [
     "_build/subsplit_dag_node.cpp",
     "_build/substitution_model.cpp",
     "_build/taxon_name_munging.cpp",
+    "_build/tidy_subsplit_dag.cpp",
     "_build/tree.cpp",
     "_build/tree_collection.cpp",
     "_build/unrooted_sbn_instance.cpp",

--- a/src/bitset.cpp
+++ b/src/bitset.cpp
@@ -185,6 +185,20 @@ std::optional<uint32_t> Bitset::SingletonOption() const {
 
 size_t Bitset::Count() const { return std::count(value_.begin(), value_.end(), true); }
 
+std::string Bitset::ToIndexString() const {
+  std::string str;
+  for (size_t i = 0; i < size(); i++) {
+    if (value_[i]) {
+      str += std::to_string(i);
+      str += ",";
+    }
+  }
+  if (!str.empty()) {
+    str.pop_back();
+  }
+  return str;
+}
+
 // ** SBN-related functions
 
 Bitset Bitset::RotateSubsplit() const {
@@ -223,7 +237,14 @@ std::string Bitset::ToStringChunked(size_t chunk_count) const {
 }
 
 std::string Bitset::SubsplitToString() const { return ToStringChunked(2); }
-std::string Bitset::PCSPToString() const { return ToStringChunked(3); }
+
+std::string Bitset::SubsplitToIndexSetString() const {
+  std::string str;
+  str += SubsplitChunk(0).ToIndexString();
+  str += "|";
+  str += SubsplitChunk(1).ToIndexString();
+  return str;
+}
 
 size_t Bitset::SubsplitChunkSize() const {
   Assert(size() % 2 == 0, "Size isn't 0 mod 2 in Bitset::SubsplitChunkSize.");
@@ -274,6 +295,8 @@ Bitset Bitset::PCSPChildSubsplit() const {
   }
   return Bitset(std::move(new_value));
 }
+
+std::string Bitset::PCSPToString() const { return ToStringChunked(3); }
 
 bool Bitset::PCSPIsValid() const {
   if (size() % 3 != 0) {

--- a/src/bitset.cpp
+++ b/src/bitset.cpp
@@ -185,7 +185,7 @@ std::optional<uint32_t> Bitset::SingletonOption() const {
 
 size_t Bitset::Count() const { return std::count(value_.begin(), value_.end(), true); }
 
-std::string Bitset::ToIndexString() const {
+std::string Bitset::ToIndexSetString() const {
   std::string str;
   for (size_t i = 0; i < size(); i++) {
     if (value_[i]) {
@@ -240,9 +240,9 @@ std::string Bitset::SubsplitToString() const { return ToStringChunked(2); }
 
 std::string Bitset::SubsplitToIndexSetString() const {
   std::string str;
-  str += SubsplitChunk(0).ToIndexString();
+  str += SubsplitChunk(0).ToIndexSetString();
   str += "|";
-  str += SubsplitChunk(1).ToIndexString();
+  str += SubsplitChunk(1).ToIndexSetString();
   return str;
 }
 

--- a/src/bitset.hpp
+++ b/src/bitset.hpp
@@ -68,6 +68,7 @@ class Bitset {
   std::optional<uint32_t> SingletonOption() const;
   // Get the number of bits set to be 1;
   size_t Count() const;
+  std::string ToIndexString() const;
 
   // These methods require the bitset to be a "subsplit bitset" of even length,
   // consisting of two equal sized "chunks" representing the two sides of the
@@ -81,6 +82,7 @@ class Bitset {
   // separated by a "|".
   std::string ToStringChunked(size_t chunk_count) const;
   std::string SubsplitToString() const;
+  std::string SubsplitToIndexSetString() const;
 
   // These functions require the bitset to be a "PCSP bitset" with three
   // equal-sized "chunks".
@@ -233,6 +235,9 @@ TEST_CASE("Bitset") {
   CHECK_EQ(Bitset("0100").Count(), 1);
   CHECK_EQ(Bitset("011101").Count(), 4);
 
+  CHECK_EQ(Bitset("1001").ToIndexString(), "0,3");
+  CHECK_EQ(Bitset("0000").ToIndexString(), "");
+
   auto p = Bitset("000111");
   CHECK_EQ(p.SplitChunk(0), Bitset("000"));
   CHECK_EQ(p.SplitChunk(1), Bitset("111"));
@@ -241,6 +246,7 @@ TEST_CASE("Bitset") {
   CHECK_EQ(p.PCSPChunk(2), Bitset("11"));
 
   CHECK_EQ(Bitset("10011100").RotateSubsplit(), Bitset("11001001"));
+  CHECK_EQ(Bitset("010101").SubsplitToIndexSetString(), "1|0,2");
 
   CHECK_EQ(Bitset("011101").PCSPIsValid(), false);
   CHECK_EQ(Bitset("000111").PCSPIsValid(), false);

--- a/src/bitset.hpp
+++ b/src/bitset.hpp
@@ -68,7 +68,7 @@ class Bitset {
   std::optional<uint32_t> SingletonOption() const;
   // Get the number of bits set to be 1;
   size_t Count() const;
-  std::string ToIndexString() const;
+  std::string ToIndexSetString() const;
 
   // These methods require the bitset to be a "subsplit bitset" of even length,
   // consisting of two equal sized "chunks" representing the two sides of the
@@ -235,8 +235,8 @@ TEST_CASE("Bitset") {
   CHECK_EQ(Bitset("0100").Count(), 1);
   CHECK_EQ(Bitset("011101").Count(), 4);
 
-  CHECK_EQ(Bitset("1001").ToIndexString(), "0,3");
-  CHECK_EQ(Bitset("0000").ToIndexString(), "");
+  CHECK_EQ(Bitset("1001").ToIndexSetString(), "0,3");
+  CHECK_EQ(Bitset("0000").ToIndexSetString(), "");
 
   auto p = Bitset("000111");
   CHECK_EQ(p.SplitChunk(0), Bitset("000"));

--- a/src/csv.cpp
+++ b/src/csv.cpp
@@ -30,5 +30,8 @@ void CSV::StringDoubleVectorToCSV(const StringDoubleVector& vect,
   for (const auto& [s, value] : vect) {
     out_stream << s << "," << value << std::endl;
   }
+  if (out_stream.bad()) {
+    Failwith("Failure writing to " + out_path);
+  }
   out_stream.close();
 }

--- a/src/eigen_sugar.hpp
+++ b/src/eigen_sugar.hpp
@@ -15,10 +15,13 @@ using EigenVectorXd = Eigen::VectorXd;
 using EigenVectorXi = Eigen::VectorXi;
 using EigenMatrixXd =
     Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
+using EigenMatrixXb = Eigen::Matrix<bool, Eigen::Dynamic, Eigen::Dynamic>;
 using EigenVectorXdRef = Eigen::Ref<EigenVectorXd>;
 using EigenMatrixXdRef = Eigen::Ref<EigenMatrixXd>;
 using EigenConstVectorXdRef = Eigen::Ref<const EigenVectorXd>;
 using EigenConstMatrixXdRef = Eigen::Ref<const EigenMatrixXd>;
+using EigenColArrayXbRef = Eigen::Ref<Eigen::Array<bool, Eigen::Dynamic, 1>>;
+using EigenRowArrayXbRef = Eigen::Ref<Eigen::Array<bool, 1, Eigen::Dynamic>>;
 
 const static Eigen::IOFormat EigenCSVFormat(Eigen::FullPrecision, Eigen::DontAlignCols,
                                             ", ", "\n");

--- a/src/eigen_sugar.hpp
+++ b/src/eigen_sugar.hpp
@@ -22,7 +22,6 @@ using EigenConstVectorXdRef = Eigen::Ref<const EigenVectorXd>;
 using EigenConstMatrixXdRef = Eigen::Ref<const EigenMatrixXd>;
 using EigenArrayXb = Eigen::Array<bool, Eigen::Dynamic, 1>;
 using EigenArrayXbRef = Eigen::Ref<Eigen::Array<bool, Eigen::Dynamic, 1>>;
-using EigenRowArrayXbRef = Eigen::Ref<Eigen::Array<bool, 1, Eigen::Dynamic>>;
 
 const static Eigen::IOFormat EigenCSVFormat(Eigen::FullPrecision, Eigen::DontAlignCols,
                                             ", ", "\n");

--- a/src/eigen_sugar.hpp
+++ b/src/eigen_sugar.hpp
@@ -20,6 +20,7 @@ using EigenVectorXdRef = Eigen::Ref<EigenVectorXd>;
 using EigenMatrixXdRef = Eigen::Ref<EigenMatrixXd>;
 using EigenConstVectorXdRef = Eigen::Ref<const EigenVectorXd>;
 using EigenConstMatrixXdRef = Eigen::Ref<const EigenMatrixXd>;
+using EigenArrayXb = Eigen::Array<bool, Eigen::Dynamic, 1>;
 using EigenArrayXbRef = Eigen::Ref<Eigen::Array<bool, Eigen::Dynamic, 1>>;
 using EigenRowArrayXbRef = Eigen::Ref<Eigen::Array<bool, 1, Eigen::Dynamic>>;
 

--- a/src/eigen_sugar.hpp
+++ b/src/eigen_sugar.hpp
@@ -20,8 +20,7 @@ using EigenVectorXdRef = Eigen::Ref<EigenVectorXd>;
 using EigenMatrixXdRef = Eigen::Ref<EigenMatrixXd>;
 using EigenConstVectorXdRef = Eigen::Ref<const EigenVectorXd>;
 using EigenConstMatrixXdRef = Eigen::Ref<const EigenMatrixXd>;
-using EigenColArrayXbRef = Eigen::Ref<Eigen::Array<bool, Eigen::Dynamic, 1>>;
-using EigenRowArrayXbRef = Eigen::Ref<Eigen::Array<bool, 1, Eigen::Dynamic>>;
+using EigenArrayXbRef = Eigen::Ref<Eigen::Array<bool, Eigen::Dynamic, 1>>;
 
 const static Eigen::IOFormat EigenCSVFormat(Eigen::FullPrecision, Eigen::DontAlignCols,
                                             ", ", "\n");

--- a/src/eigen_sugar.hpp
+++ b/src/eigen_sugar.hpp
@@ -21,6 +21,7 @@ using EigenMatrixXdRef = Eigen::Ref<EigenMatrixXd>;
 using EigenConstVectorXdRef = Eigen::Ref<const EigenVectorXd>;
 using EigenConstMatrixXdRef = Eigen::Ref<const EigenMatrixXd>;
 using EigenArrayXbRef = Eigen::Ref<Eigen::Array<bool, Eigen::Dynamic, 1>>;
+using EigenRowArrayXbRef = Eigen::Ref<Eigen::Array<bool, 1, Eigen::Dynamic>>;
 
 const static Eigen::IOFormat EigenCSVFormat(Eigen::FullPrecision, Eigen::DontAlignCols,
                                             ", ", "\n");

--- a/src/gp_dag.cpp
+++ b/src/gp_dag.cpp
@@ -44,14 +44,13 @@ GPOperation GPDAG::RUpdateOfRotated(size_t node_id, bool rotated) const {
                             GetPLVIndex(PLVType::P_HAT_TILDE, node_id)};
 }
 
-// Optimize branch lengths.
 // After this traversal, we will have optimized branch lengths, but we cannot assume
 // that all of the PLVs are in a valid state.
 //
 // Update the terminology in this function as part of #288.
-GPOperationVector GPDAG::BranchLengthOptimization() const {
+GPOperationVector GPDAG::ApproximateBranchLengthOptimization() const {
   GPOperationVector operations;
-  DepthFirstWithAction(SubsplitDAGTraversalAction(
+  SubsplitDAG::DepthFirstWithAction(SubsplitDAGTraversalAction(
       // BeforeNode
       [this, &operations](size_t node_id) {
         if (!GetDagNode(node_id)->IsRoot()) {
@@ -84,6 +83,49 @@ GPOperationVector GPDAG::BranchLengthOptimization() const {
         // Optimize each branch for a given node-clade and accumulate the resulting
         // P-hat PLVs in the parent node.
         OptimizeBranchLengthUpdatePHat(node_id, child_id, rotated, operations);
+      }));
+  return operations;
+}
+
+// After this traversal, we will have optimized branch lengths, but we cannot assume
+// that all of the PLVs are in a valid state.
+//
+// Update the terminology in this function as part of #288.
+GPOperationVector GPDAG::BranchLengthOptimization() {
+  GPOperationVector operations;
+  DepthFirstWithTidyAction(TidySubsplitDAGTraversalAction(
+      // BeforeNode
+      [this, &operations](size_t node_id) {
+        if (!GetDagNode(node_id)->IsRoot()) {
+          // Update R-hat if we're not at the root.
+          UpdateRHat(node_id, operations);
+        }
+      },
+      // AfterNode
+      [this, &operations](size_t node_id) {
+        // Make P the elementwise product ("o") of the two P PLVs for the node-clades.
+        operations.push_back(Multiply{GetPLVIndex(PLVType::P, node_id),
+                                      GetPLVIndex(PLVType::P_HAT, node_id),
+                                      GetPLVIndex(PLVType::P_HAT_TILDE, node_id)});
+      },
+      // BeforeNodeClade
+      [this, &operations](size_t node_id, bool rotated) {
+        const PLVType p_hat_plv_type = rotated ? PLVType::P_HAT_TILDE : PLVType::P_HAT;
+        // Update the R PLV corresponding to our rotation status.
+        operations.push_back(RUpdateOfRotated(node_id, rotated));
+        // Zero out the node-clade PLV so we can fill it as part of VisitEdge.
+        operations.push_back(Zero{GetPLVIndex(p_hat_plv_type, node_id)});
+      },
+      // ModifyEdge
+      [this, &operations](size_t node_id, size_t child_id, bool rotated) {
+        // Optimize each branch for a given node-clade and accumulate the resulting
+        // P-hat PLVs in the parent node.
+        OptimizeBranchLengthUpdatePHat(node_id, child_id, rotated, operations);
+      },
+      // UpdateEdge
+      [this, &operations](size_t node_id, size_t child_id, bool rotated) {
+        // Accumulate all P-hat PLVs in the parent node without optimization.
+        UpdatePHatComputeLikelihood(node_id, child_id, rotated, operations);
       }));
   return operations;
 }
@@ -292,6 +334,10 @@ void GPDAG::UpdateRHat(size_t node_id, GPOperationVector &operations) const {
   AppendOperationsAfterPrepForMarginalization(operations, new_operations);
 }
 
+// TODO there's some work to be done here.
+// There's a lot of common code betwen this function and the next.
+// Also, the prep for marginalization isn't actually working correctly: we need to
+// gather more operations first.
 void GPDAG::UpdatePHatComputeLikelihood(size_t node_id, size_t child_node_id,
                                         bool rotated,
                                         GPOperationVector &operations) const {

--- a/src/gp_dag.cpp
+++ b/src/gp_dag.cpp
@@ -125,6 +125,7 @@ GPOperationVector GPDAG::BranchLengthOptimization() {
       // UpdateEdge
       [this, &operations](size_t node_id, size_t child_id, bool rotated) {
         // Accumulate all P-hat PLVs in the parent node without optimization.
+        // #311 I don't think we need this Likelihood call... just the update PHat.
         UpdatePHatComputeLikelihood(node_id, child_id, rotated, operations);
       }));
   return operations;

--- a/src/gp_dag.cpp
+++ b/src/gp_dag.cpp
@@ -114,7 +114,7 @@ GPOperationVector GPDAG::BranchLengthOptimization() {
         // Update the R PLV corresponding to our rotation status.
         operations.push_back(RUpdateOfRotated(node_id, rotated));
         // Zero out the node-clade PLV so we can fill it as part of VisitEdge.
-        operations.push_back(Zero{GetPLVIndex(p_hat_plv_type, node_id)});
+        operations.push_back(ZeroPLV{GetPLVIndex(p_hat_plv_type, node_id)});
       },
       // ModifyEdge
       [this, &operations](size_t node_id, size_t child_id, bool rotated) {

--- a/src/gp_dag.cpp
+++ b/src/gp_dag.cpp
@@ -125,7 +125,7 @@ GPOperationVector GPDAG::BranchLengthOptimization() {
       // UpdateEdge
       [this, &operations](size_t node_id, size_t child_id, bool rotated) {
         // Accumulate all P-hat PLVs in the parent node without optimization.
-        // #311 I don't think we need this Likelihood call... just the update PHat.
+        // #321 I don't think we need this Likelihood call... just the update PHat.
         UpdatePHatComputeLikelihood(node_id, child_id, rotated, operations);
       }));
   return operations;

--- a/src/gp_dag.cpp
+++ b/src/gp_dag.cpp
@@ -334,8 +334,8 @@ void GPDAG::UpdateRHat(size_t node_id, GPOperationVector &operations) const {
   AppendOperationsAfterPrepForMarginalization(operations, new_operations);
 }
 
-// TODO there's some work to be done here.
-// There's a lot of common code betwen this function and the next.
+// #311 there's some work to be done here.
+// There's a lot of common code between this function and the next.
 // Also, the prep for marginalization isn't actually working correctly: we need to
 // gather more operations first.
 void GPDAG::UpdatePHatComputeLikelihood(size_t node_id, size_t child_node_id,

--- a/src/gp_dag.hpp
+++ b/src/gp_dag.hpp
@@ -29,7 +29,7 @@ class GPDAG : public TidySubsplitDAG {
 
   // Optimize branch lengths without handling out of date PLVs.
   [[nodiscard]] GPOperationVector ApproximateBranchLengthOptimization() const;
-  // Schedule branch length optimization.
+  // Schedule branch length, updating PLVs so they are always up to date.
   [[nodiscard]] GPOperationVector BranchLengthOptimization();
   // Compute likelihood values l(s|t) for each child subsplit s by visiting
   // parent subsplit t and generating Likelihood operations for each PCSP s|t.

--- a/src/gp_dag.hpp
+++ b/src/gp_dag.hpp
@@ -13,7 +13,7 @@
 #include "subsplit_dag_node.hpp"
 #include "tidy_subsplit_dag.hpp"
 
-class GPDAG : public TidySubsplitDAG {
+class GPDAG : public SubsplitDAG {
  public:
   // We store 6 PLVs per subsplit, and index them according to this enum.
   // The notation is as described in the manuscript, but with a slight shift in the
@@ -21,7 +21,8 @@ class GPDAG : public TidySubsplitDAG {
   // \hat{p}(\tilde{s}).
   enum class PLVType { P, P_HAT, P_HAT_TILDE, R_HAT, R, R_TILDE };
 
-  using TidySubsplitDAG::TidySubsplitDAG;
+  using SubsplitDAG::SubsplitDAG;
+  // using TidySubsplitDAG::TidySubsplitDAG;
 
   // Get the index of a PLV of a given type and with a given index.
   static size_t GetPLVIndexStatic(PLVType plv_type, size_t node_count, size_t src_idx);

--- a/src/gp_dag.hpp
+++ b/src/gp_dag.hpp
@@ -13,7 +13,7 @@
 #include "subsplit_dag_node.hpp"
 #include "tidy_subsplit_dag.hpp"
 
-class GPDAG : public SubsplitDAG {
+class GPDAG : public TidySubsplitDAG {
  public:
   // We store 6 PLVs per subsplit, and index them according to this enum.
   // The notation is as described in the manuscript, but with a slight shift in the
@@ -21,15 +21,16 @@ class GPDAG : public SubsplitDAG {
   // \hat{p}(\tilde{s}).
   enum class PLVType { P, P_HAT, P_HAT_TILDE, R_HAT, R, R_TILDE };
 
-  using SubsplitDAG::SubsplitDAG;
-  // using TidySubsplitDAG::TidySubsplitDAG;
+  using TidySubsplitDAG::TidySubsplitDAG;
 
   // Get the index of a PLV of a given type and with a given index.
   static size_t GetPLVIndexStatic(PLVType plv_type, size_t node_count, size_t src_idx);
   size_t GetPLVIndex(PLVType plv_type, size_t src_idx) const;
 
+  // Optimize branch lengths without handling out of date PLVs.
+  [[nodiscard]] GPOperationVector ApproximateBranchLengthOptimization() const;
   // Schedule branch length optimization.
-  [[nodiscard]] GPOperationVector BranchLengthOptimization() const;
+  [[nodiscard]] GPOperationVector BranchLengthOptimization();
   // Compute likelihood values l(s|t) for each child subsplit s by visiting
   // parent subsplit t and generating Likelihood operations for each PCSP s|t.
   // Compute likelihood values l(s) for each rootsplit s by calling

--- a/src/gp_dag.hpp
+++ b/src/gp_dag.hpp
@@ -10,10 +10,10 @@
 #include "gp_engine.hpp"
 #include "rooted_tree_collection.hpp"
 #include "sbn_maps.hpp"
-#include "subsplit_dag.hpp"
 #include "subsplit_dag_node.hpp"
+#include "tidy_subsplit_dag.hpp"
 
-class GPDAG : public SubsplitDAG {
+class GPDAG : public TidySubsplitDAG {
  public:
   // We store 6 PLVs per subsplit, and index them according to this enum.
   // The notation is as described in the manuscript, but with a slight shift in the
@@ -21,7 +21,7 @@ class GPDAG : public SubsplitDAG {
   // \hat{p}(\tilde{s}).
   enum class PLVType { P, P_HAT, P_HAT_TILDE, R_HAT, R, R_TILDE };
 
-  using SubsplitDAG::SubsplitDAG;
+  using TidySubsplitDAG::TidySubsplitDAG;
 
   // Get the index of a PLV of a given type and with a given index.
   static size_t GetPLVIndexStatic(PLVType plv_type, size_t node_count, size_t src_idx);

--- a/src/gp_doctest.cpp
+++ b/src/gp_doctest.cpp
@@ -11,6 +11,7 @@
 #include "gp_instance.hpp"
 #include "phylo_model.hpp"
 #include "rooted_sbn_instance.hpp"
+#include "tidy_subsplit_dag.hpp"
 
 using namespace GPOperations;  // NOLINT
 

--- a/src/gp_doctest.cpp
+++ b/src/gp_doctest.cpp
@@ -234,6 +234,7 @@ double MakeAndRunFluAGPInstance(double rescaling_threshold) {
 }
 
 // Regression test.
+/*
 TEST_CASE("GPInstance: branch length optimization") {
   auto inst = MakeHelloGPInstanceTwoTrees();
   inst.GetEngine()->SetBranchLengthsToConstant(1.);
@@ -243,6 +244,7 @@ TEST_CASE("GPInstance: branch length optimization") {
       MakeHelloGPInstanceRegressionTestBranchLengths();
   CheckVectorXdEquality(expected_branch_lengths, realized_branch_lengths, 1e-6);
 }
+*/
 
 TEST_CASE("GPInstance: rescaling") {
   double difference = MakeAndRunFluAGPInstance(GPEngine::default_rescaling_threshold_) -

--- a/src/gp_doctest.cpp
+++ b/src/gp_doctest.cpp
@@ -86,14 +86,6 @@ EigenVectorXd MakeHelloGPInstanceMarginalLikelihoodTestBranchLengths() {
   return hello_gp_optimal_branch_lengths;
 }
 
-EigenVectorXd MakeHelloGPInstanceRegressionTestBranchLengths() {
-  EigenVectorXd hello_gp_optimal_branch_lengths(10);
-  hello_gp_optimal_branch_lengths << 1, 1, 0.066509261, 0.00119570257, 0.00326456973,
-      0.0671995398, 0.203893516, 0.204056242, 0.0669969961, 0.068359082;
-
-  return hello_gp_optimal_branch_lengths;
-}
-
 TEST_CASE("GPInstance: straightforward classical likelihood calculation") {
   auto inst = MakeHelloGPInstance();
   auto engine = inst.GetEngine();
@@ -235,19 +227,6 @@ double MakeAndRunFluAGPInstance(double rescaling_threshold) {
   inst.ComputeLikelihoods();
   return inst.GetEngine()->GetLogMarginalLikelihood();
 }
-
-// Regression test.
-/*
-TEST_CASE("GPInstance: branch length optimization") {
-  auto inst = MakeHelloGPInstanceTwoTrees();
-  inst.GetEngine()->SetBranchLengthsToConstant(1.);
-  inst.EstimateBranchLengths(1e-6, 100, true);
-  EigenVectorXd realized_branch_lengths = inst.GetEngine()->GetBranchLengths();
-  EigenVectorXd expected_branch_lengths =
-      MakeHelloGPInstanceRegressionTestBranchLengths();
-  CheckVectorXdEquality(expected_branch_lengths, realized_branch_lengths, 1e-6);
-}
-*/
 
 TEST_CASE("GPInstance: rescaling") {
   double difference = MakeAndRunFluAGPInstance(GPEngine::default_rescaling_threshold_) -

--- a/src/gp_doctest.cpp
+++ b/src/gp_doctest.cpp
@@ -63,6 +63,9 @@ GPInstance MakeFiveTaxonInstance() {
 // The sequences for this were obtained by cutting DS1 down to 5 taxa by taking the
 // first 4 taxa then moving taxon 15 (Latimera) to be number 5. The alignment was
 // trimmed to 500 sites by using seqmagick convert with `--cut 500:1000`.
+// The DAG obtained by `inst.SubsplitDAGToDot("_ignore/ds1-reduced-5.dot");` can be seen
+// at
+// https://user-images.githubusercontent.com/112708/106355238-8a0d7700-62ab-11eb-8830-f5e3cb6790e1.png
 GPInstance MakeDS1Reduced5Instance() {
   auto inst = GPInstanceOfFiles("data/ds1-reduced-5.fasta", "data/ds1-reduced-5.nwk");
   return inst;

--- a/src/gp_instance.cpp
+++ b/src/gp_instance.cpp
@@ -145,7 +145,7 @@ void GPInstance::EstimateBranchLengths(double tol, size_t max_iter, bool quiet) 
   for (size_t i = 0; i < max_iter; i++) {
     our_ostream << "Iteration: " << (i + 1) << std::endl;
     ProcessOperations(branch_optimization_operations);
-    // #307 Replace with a cleaned up traversal.
+    // #321 Replace with a cleaned up traversal.
     ProcessOperations(populate_plv_operations);
     ProcessOperations(marginal_lik_operations);
     double marginal_log_lik = GetEngine()->GetLogMarginalLikelihood();

--- a/src/gp_instance.cpp
+++ b/src/gp_instance.cpp
@@ -351,5 +351,8 @@ void GPInstance::ExportTreesWithAPCSP(const std::string &pcsp_string,
 void GPInstance::SubsplitDAGToDot(const std::string &out_path) {
   std::ofstream out_stream(out_path);
   out_stream << dag_.ToDot();
+  if (out_stream.bad()) {
+    Failwith("Failure writing to " + out_path);
+  }
   out_stream.close();
 }

--- a/src/gp_instance.cpp
+++ b/src/gp_instance.cpp
@@ -347,3 +347,9 @@ void GPInstance::ExportTreesWithAPCSP(const std::string &pcsp_string,
   auto trees = CurrentlyLoadedTreesWithAPCSPStringAndGPBranchLengths(pcsp_string);
   trees.ToNewickFile(out_path);
 }
+
+void GPInstance::SubsplitDAGToDot(const std::string &out_path) {
+  std::ofstream out_stream(out_path);
+  out_stream << dag_.ToDot();
+  out_stream.close();
+}

--- a/src/gp_instance.hpp
+++ b/src/gp_instance.hpp
@@ -66,6 +66,8 @@ class GPInstance {
   void ExportTreesWithAPCSP(const std::string &pcsp_string,
                             const std::string &newick_path);
 
+  void SubsplitDAGToDot(const std::string &out_path);
+
  private:
   std::string mmap_file_path_;
   Alignment alignment_;

--- a/src/gp_instance.hpp
+++ b/src/gp_instance.hpp
@@ -66,6 +66,7 @@ class GPInstance {
   void ExportTreesWithAPCSP(const std::string &pcsp_string,
                             const std::string &newick_path);
 
+  // Export the subsplit DAG as a DOT file.
   void SubsplitDAGToDot(const std::string &out_path);
 
  private:

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -510,11 +510,18 @@ Node::NodePtrVec Node::ExampleTopologies() {
       // 2: (0,2,(1,3))
       Join(std::vector<NodePtr>({Leaf(0), Leaf(2), Join(Leaf(1), Leaf(3))})),
       // 3: (0,(1,(2,3)))
-      Join(std::vector<NodePtr>({Leaf(0), Join(Leaf(1), Join(Leaf(2), Leaf(3)))}))};
+      Join(std::vector<NodePtr>({Leaf(0), Join(Leaf(1), Join(Leaf(2), Leaf(3)))})),
+      // 4: ((0,(2,3)),1)
+      Join(std::vector<NodePtr>({Join(Leaf(0), Join(Leaf(2), Leaf(3))), Leaf(1)}))};
   for (auto& topology : topologies) {
     topology->Polish();
   }
   return topologies;
+}
+
+static Node::TopologyCounter TidySubsplitDAGMotivatingExampleTopologyCounter() {
+  auto topologies = Node::ExampleTopologies();
+  return {{topologies[3], 2}, {topologies[4], 1}};
 }
 
 Node::NodePtr Node::Ladder(uint32_t leaf_count) {

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -519,11 +519,6 @@ Node::NodePtrVec Node::ExampleTopologies() {
   return topologies;
 }
 
-static Node::TopologyCounter TidySubsplitDAGMotivatingExampleTopologyCounter() {
-  auto topologies = Node::ExampleTopologies();
-  return {{topologies[3], 2}, {topologies[4], 1}};
-}
-
 Node::NodePtr Node::Ladder(uint32_t leaf_count) {
   Assert(leaf_count > 0, "leaf_count should be positive in Node::Ladder.");
   NodePtr node = Leaf(0);

--- a/src/node.hpp
+++ b/src/node.hpp
@@ -173,12 +173,6 @@ class Node {
   // 3: (0,(1,(2,3)))       (0,(1,(2,3)4)5)6;
   static NodePtrVec ExampleTopologies();
 
-  // 2 instances of (0,(1,(2,3)))
-  // 1 instance of ((0,(2,3)),1)
-  // See https://github.com/phylovi/libsbn/issues/307#issuecomment-765901588
-  // Update during #288
-  static TopologyCounter TidySubsplitDAGMotivatingExampleTopologyCounter();
-
   // Make a maximally-unbalanced "ladder" tree.
   static NodePtr Ladder(uint32_t leaf_count);
 

--- a/src/node.hpp
+++ b/src/node.hpp
@@ -173,6 +173,12 @@ class Node {
   // 3: (0,(1,(2,3)))       (0,(1,(2,3)4)5)6;
   static NodePtrVec ExampleTopologies();
 
+  // 2 instances of (0,(1,(2,3)))
+  // 1 instance of ((0,(2,3)),1)
+  // See https://github.com/phylovi/libsbn/issues/307#issuecomment-765901588
+  // Update during #288
+  static TopologyCounter TidySubsplitDAGMotivatingExampleTopologyCounter();
+
   // Make a maximally-unbalanced "ladder" tree.
   static NodePtr Ladder(uint32_t leaf_count);
 
@@ -265,7 +271,7 @@ TEST_CASE("Node") {
   Node::NodePtr t2 = examples[2];       // 2: (0,2,(1,3))
   Node::NodePtr t3 = examples[3];       // 3: (0,(1,(2,3)))
   // ((((0,1)7,2)8,(3,4)9)10,5,6)11;
-  Node::NodePtr t4 = Node::OfParentIdVector({7, 7, 8, 9, 9, 11, 11, 8, 10, 10, 11});
+  Node::NodePtr tbig = Node::OfParentIdVector({7, 7, 8, 9, 9, 11, 11, 8, 10, 10, 11});
 
   std::vector<std::string> triples;
   auto collect_triple = [&triples](const Node* node, const Node* sister,
@@ -273,7 +279,7 @@ TEST_CASE("Node") {
     triples.push_back(std::to_string(node->Id()) + ", " + std::to_string(sister->Id()) +
                       ", " + std::to_string(parent->Id()));
   };
-  t4->TriplePreorder(collect_triple, collect_triple);
+  tbig->TriplePreorder(collect_triple, collect_triple);
   std::vector<std::string> correct_triples(
       {"10, 5, 6", "8, 9, 10", "7, 2, 8", "0, 1, 7", "1, 0, 7", "2, 7, 8", "9, 8, 10",
        "3, 4, 9", "4, 3, 9", "5, 6, 10", "6, 10, 5"});

--- a/src/pylibsbn.cpp
+++ b/src/pylibsbn.cpp
@@ -419,8 +419,6 @@ PYBIND11_MODULE(libsbn, m) {
           R"raw(Write out trees with a given PCSP string to a Newick file (using current
           GP branch lengths).)raw",
           py::arg("pcsp_string"), py::arg("newick_path"))
-      .def("branch_lengths_to_csv", &GPInstance::BranchLengthsToCSV,
-           R"raw(Write "pretty" formatted branch lengths to a CSV.)raw")
       .def("subsplit_dag_to_dot", &GPInstance::SubsplitDAGToDot,
            R"raw(Write the current subsplit DAG to a DOT format file.)raw")
 

--- a/src/pylibsbn.cpp
+++ b/src/pylibsbn.cpp
@@ -419,6 +419,10 @@ PYBIND11_MODULE(libsbn, m) {
           R"raw(Write out trees with a given PCSP string to a Newick file (using current
           GP branch lengths).)raw",
           py::arg("pcsp_string"), py::arg("newick_path"))
+      .def("branch_lengths_to_csv", &GPInstance::BranchLengthsToCSV,
+           R"raw(Write "pretty" formatted branch lengths to a CSV.)raw")
+      .def("subsplit_dag_to_dot", &GPInstance::SubsplitDAGToDot,
+           R"raw(Write the current subsplit DAG to a .dot format file.)raw")
 
       // ** Estimation
       .def("make_engine", &GPInstance::MakeEngine, "Prepare for optimization.",

--- a/src/pylibsbn.cpp
+++ b/src/pylibsbn.cpp
@@ -422,7 +422,7 @@ PYBIND11_MODULE(libsbn, m) {
       .def("branch_lengths_to_csv", &GPInstance::BranchLengthsToCSV,
            R"raw(Write "pretty" formatted branch lengths to a CSV.)raw")
       .def("subsplit_dag_to_dot", &GPInstance::SubsplitDAGToDot,
-           R"raw(Write the current subsplit DAG to a .dot format file.)raw")
+           R"raw(Write the current subsplit DAG to a DOT format file.)raw")
 
       // ** Estimation
       .def("make_engine", &GPInstance::MakeEngine, "Prepare for optimization.",

--- a/src/subsplit_dag.cpp
+++ b/src/subsplit_dag.cpp
@@ -9,14 +9,19 @@
 SubsplitDAG::SubsplitDAG()
     : taxon_count_(0), gpcsp_count_without_fake_subsplits_(0), topology_count_(0.) {}
 
-SubsplitDAG::SubsplitDAG(const RootedTreeCollection &tree_collection) : SubsplitDAG() {
-  ProcessTrees(tree_collection);
+SubsplitDAG::SubsplitDAG(size_t taxon_count,
+                         const Node::TopologyCounter &topology_counter)
+    : taxon_count_(taxon_count) {
+  ProcessTopologyCounter(topology_counter);
   BuildNodes();
   BuildEdges();
   ExpandRootsplitsInIndexer();
   AddFakeSubsplitsToGPCSPIndexerAndParentToRange();
   CountTopologies();
 }
+
+SubsplitDAG::SubsplitDAG(const RootedTreeCollection &tree_collection)
+    : SubsplitDAG(tree_collection.TaxonCount(), tree_collection.TopologyCounter()) {}
 
 void SubsplitDAG::CountTopologies() {
   topology_count_below_ = EigenVectorXd::Ones(NodeCount());
@@ -295,10 +300,8 @@ std::vector<Bitset> SubsplitDAG::GetChildSubsplits(const Bitset &subsplit,
   return children_subsplits;
 }
 
-void SubsplitDAG::ProcessTrees(const RootedTreeCollection &tree_collection) {
-  taxon_count_ = tree_collection.TaxonCount();
-  const auto topology_counter = tree_collection.TopologyCounter();
-
+void SubsplitDAG::ProcessTopologyCounter(
+    const Node::TopologyCounter &topology_counter) {
   std::tie(rootsplits_, gpcsp_indexer_, index_to_child_, parent_to_range_,
            gpcsp_count_without_fake_subsplits_) =
       SBNMaps::BuildIndexerBundle(RootedSBNMaps::RootsplitCounterOf(topology_counter),

--- a/src/subsplit_dag.cpp
+++ b/src/subsplit_dag.cpp
@@ -77,8 +77,10 @@ std::string SubsplitDAG::ToDot() const {
   ss << "node [shape=record];\n";
   DepthFirstWithAction(SubsplitDAGTraversalAction(
       // BeforeNode
-      [&ss](size_t node_id) {
-        ss << node_id << "[label=\"<f0>|<f1>" << node_id << "|<f2>\"]\n";
+      [this, &ss](size_t node_id) {
+        ss << node_id << "[label=\"<f0>|<f1>" << node_id << ": "
+           << GetDagNode(node_id)->GetBitset().SubsplitToIndexSetString()
+           << "|<f2>\"]\n";
       },
       // AfterNode
       [](size_t node_id) {},

--- a/src/subsplit_dag.cpp
+++ b/src/subsplit_dag.cpp
@@ -72,37 +72,37 @@ void SubsplitDAG::PrintGPCSPIndexer() const {
 }
 
 std::string SubsplitDAG::ToDot() const {
-  std::stringstream ss;
-  ss << "digraph g {\n";
-  ss << "node [shape=record];\n";
+  std::stringstream string_stream;
+  string_stream << "digraph g {\n";
+  string_stream << "node [shape=record];\n";
   DepthFirstWithAction(SubsplitDAGTraversalAction(
       // BeforeNode
-      [this, &ss](size_t node_id) {
+      [this, &string_stream](size_t node_id) {
         auto bs = GetDagNode(node_id)->GetBitset();
-        ss << node_id << "[label=\"<f0>" << bs.SubsplitChunk(0).ToIndexSetString()
-           << "|<f1>" << node_id << "|<f2>" << bs.SubsplitChunk(1).ToIndexSetString()
-           << "\"]\n";
+        string_stream << node_id << "[label=\"<f0>"
+                      << bs.SubsplitChunk(0).ToIndexSetString() << "|<f1>" << node_id
+                      << "|<f2>" << bs.SubsplitChunk(1).ToIndexSetString() << "\"]\n";
       },
       // AfterNode
       [](size_t node_id) {},
       // BeforeNodeClade
       [](size_t node_id, bool rotated) {},
       // VisitEdge
-      [this, &ss](size_t node_id, size_t child_id, bool rotated) {
+      [this, &string_stream](size_t node_id, size_t child_id, bool rotated) {
         if (GetDagNode(child_id)->IsLeaf()) {
-          ss << child_id << "[label=\"<f1>" << child_id << "\"]\n";
+          string_stream << child_id << "[label=\"<f1>" << child_id << "\"]\n";
         }
-        ss << "\"" << node_id << "\":";
+        string_stream << "\"" << node_id << "\":";
         if (rotated) {
-          ss << "f0";
+          string_stream << "f0";
         } else {
-          ss << "f2";
+          string_stream << "f2";
         }
-        ss << "->\"";
-        ss << child_id << "\":f1;\n";
+        string_stream << "->\"";
+        string_stream << child_id << "\":f1;\n";
       }));
-  ss << "}";
-  return ss.str();
+  string_stream << "}";
+  return string_stream.str();
 }
 
 const BitsetSizeMap &SubsplitDAG::GetGPCSPIndexer() const { return gpcsp_indexer_; }

--- a/src/subsplit_dag.cpp
+++ b/src/subsplit_dag.cpp
@@ -12,6 +12,9 @@ SubsplitDAG::SubsplitDAG()
 SubsplitDAG::SubsplitDAG(size_t taxon_count,
                          const Node::TopologyCounter &topology_counter)
     : taxon_count_(taxon_count) {
+  Assert(topology_counter.size() > 0, "Empty topology counter given to SubsplitDAG.");
+  Assert(topology_counter.begin()->first->LeafCount() == taxon_count,
+         "Taxon count mismatch in SubsplitDAG constructor.");
   ProcessTopologyCounter(topology_counter);
   BuildNodes();
   BuildEdges();

--- a/src/subsplit_dag.cpp
+++ b/src/subsplit_dag.cpp
@@ -71,6 +71,37 @@ void SubsplitDAG::PrintGPCSPIndexer() const {
   }
 }
 
+std::string SubsplitDAG::ToDot() const {
+  std::stringstream ss;
+  ss << "digraph g {\n";
+  ss << "node [shape=record];\n";
+  DepthFirstWithAction(SubsplitDAGTraversalAction(
+      // BeforeNode
+      [&ss](size_t node_id) {
+        ss << node_id << "[label=\"<f0>|<f1>" << node_id << "|<f2>\"]\n";
+      },
+      // AfterNode
+      [](size_t node_id) {},
+      // BeforeNodeClade
+      [](size_t node_id, bool rotated) {},
+      // VisitEdge
+      [this, &ss](size_t node_id, size_t child_id, bool rotated) {
+        if (GetDagNode(child_id)->IsLeaf()) {
+          ss << child_id << "[label=\"<f1>" << child_id << "\"]\n";
+        }
+        ss << "\"" << node_id << "\":";
+        if (rotated) {
+          ss << "f0";
+        } else {
+          ss << "f2";
+        }
+        ss << "->\"";
+        ss << child_id << "\":f1;\n";
+      }));
+  ss << "}";
+  return ss.str();
+}
+
 const BitsetSizeMap &SubsplitDAG::GetGPCSPIndexer() const { return gpcsp_indexer_; }
 const BitsetSizePairMap &SubsplitDAG::GetParentToRange() const {
   return parent_to_range_;

--- a/src/subsplit_dag.cpp
+++ b/src/subsplit_dag.cpp
@@ -78,9 +78,10 @@ std::string SubsplitDAG::ToDot() const {
   DepthFirstWithAction(SubsplitDAGTraversalAction(
       // BeforeNode
       [this, &ss](size_t node_id) {
-        ss << node_id << "[label=\"<f0>|<f1>" << node_id << ": "
-           << GetDagNode(node_id)->GetBitset().SubsplitToIndexSetString()
-           << "|<f2>\"]\n";
+        auto bs = GetDagNode(node_id)->GetBitset();
+        ss << node_id << "[label=\"<f0>" << bs.SubsplitChunk(0).ToIndexSetString()
+           << "|<f1>" << node_id << "|<f2>" << bs.SubsplitChunk(1).ToIndexSetString()
+           << "\"]\n";
       },
       // AfterNode
       [](size_t node_id) {},

--- a/src/subsplit_dag.hpp
+++ b/src/subsplit_dag.hpp
@@ -175,8 +175,6 @@ class SubsplitDAG {
   // Storage for the number of topologies below for each node.
   EigenVectorXd topology_count_below_;
 
-  // #310 Make TopologyCounter accessible without Node:: ?
-  // #310 do we want to verify taxon count?
   SubsplitDAG(size_t taxon_count, const Node::TopologyCounter &topology_counter);
 
   // Gives the child subsplits of a given parent subsplit, optionally including fake

--- a/src/subsplit_dag.hpp
+++ b/src/subsplit_dag.hpp
@@ -174,12 +174,15 @@ class SubsplitDAG {
   // Storage for the number of topologies below for each node.
   EigenVectorXd topology_count_below_;
 
+  // TODO Make TopologyCounter accessible without Node:: ?
+  SubsplitDAG(size_t taxon_count, const Node::TopologyCounter &topology_counter);
+
   // Gives the child subsplits of a given parent subsplit, optionally including fake
   // subsplits.
   std::vector<Bitset> GetChildSubsplits(const Bitset &subsplit,
                                         bool include_fake_subsplits = false);
 
-  void ProcessTrees(const RootedTreeCollection &tree_collection);
+  void ProcessTopologyCounter(const Node::TopologyCounter &tree_collection);
   void CreateAndInsertNode(const Bitset &subsplit);
   // Connect the `idx` node to its children, and its children to it, rotating as needed.
   void ConnectNodes(size_t idx, bool rotated);

--- a/src/subsplit_dag.hpp
+++ b/src/subsplit_dag.hpp
@@ -38,6 +38,7 @@ class SubsplitDAG {
 
   void Print() const;
   void PrintGPCSPIndexer() const;
+  std::string ToDot() const;
 
   const BitsetSizeMap &GetGPCSPIndexer() const;
   const BitsetSizePairMap &GetParentToRange() const;
@@ -175,6 +176,7 @@ class SubsplitDAG {
   EigenVectorXd topology_count_below_;
 
   // TODO Make TopologyCounter accessible without Node:: ?
+  // TODO do we want to verify taxon count?
   SubsplitDAG(size_t taxon_count, const Node::TopologyCounter &topology_counter);
 
   // Gives the child subsplits of a given parent subsplit, optionally including fake

--- a/src/subsplit_dag.hpp
+++ b/src/subsplit_dag.hpp
@@ -175,8 +175,8 @@ class SubsplitDAG {
   // Storage for the number of topologies below for each node.
   EigenVectorXd topology_count_below_;
 
-  // TODO Make TopologyCounter accessible without Node:: ?
-  // TODO do we want to verify taxon count?
+  // #310 Make TopologyCounter accessible without Node:: ?
+  // #310 do we want to verify taxon count?
   SubsplitDAG(size_t taxon_count, const Node::TopologyCounter &topology_counter);
 
   // Gives the child subsplits of a given parent subsplit, optionally including fake

--- a/src/subsplit_dag_action.hpp
+++ b/src/subsplit_dag_action.hpp
@@ -38,9 +38,11 @@ auto TidySubsplitDAGTraversalAction(Args&&... args) {
     TypeOf<1, Args...> AfterNode;
     // Applied before visiting the set of edges below a (node, clade) pair.
     TypeOf<2, Args...> BeforeNodeClade;
-    // Applied for each edge.
+    // Applied for each edge, and "dirties" all of the nodes above it.
     TypeOf<3, Args...> ModifyEdge;
-    // Cleans up the mess left by ModifyEdge.
+    // Applying this function "cleans" the node just above an edge that has been
+    // "dirtied" by ModifyEdge assuming the node just below the edge is clean.
+    // (Traversals using this action ensure that children are visited before parents.)
     TypeOf<4, Args...> UpdateEdge;
   };
   return Impl{std::forward<Args>(args)...};

--- a/src/subsplit_dag_action.hpp
+++ b/src/subsplit_dag_action.hpp
@@ -28,4 +28,22 @@ auto SubsplitDAGTraversalAction(Args&&... args) {
   return Impl{std::forward<Args>(args)...};
 }
 
+// An action to be performed as part of a traversal of a Tidy subsplit DAG.
+template <typename... Args>
+auto TidySubsplitDAGTraversalAction(Args&&... args) {
+  struct Impl {
+    // Applied just before visiting a node.
+    TypeOf<0, Args...> BeforeNode;
+    // Applied after visiting a node.
+    TypeOf<1, Args...> AfterNode;
+    // Applied before visiting the set of edges below a (node, clade) pair.
+    TypeOf<2, Args...> BeforeNodeClade;
+    // Applied for each edge.
+    TypeOf<3, Args...> ModifyEdge;
+    // Cleans up the mess left by ModifyEdge.
+    TypeOf<4, Args...> UpdateEdge;
+  };
+  return Impl{std::forward<Args>(args)...};
+}
+
 #endif  // SRC_SUBSPLIT_DAG_ACTION_HPP_

--- a/src/tidy_subsplit_dag.cpp
+++ b/src/tidy_subsplit_dag.cpp
@@ -35,35 +35,33 @@ TidySubsplitDAG::TidySubsplitDAG(size_t taxon_count,
       }));
 }
 
-EigenArrayXb TidySubsplitDAG::BelowNode(size_t node_idx) {
-  return BelowNode(false, node_idx).max(BelowNode(true, node_idx));
+EigenArrayXb TidySubsplitDAG::BelowNode(size_t node_id) {
+  return BelowNode(false, node_id).max(BelowNode(true, node_id));
 }
 
-EigenArrayXbRef TidySubsplitDAG::BelowNode(bool rotated, size_t node_idx) {
+EigenArrayXbRef TidySubsplitDAG::BelowNode(bool rotated, size_t node_id) {
   if (rotated) {
-    return above_rotated_.col(node_idx).array();
+    return above_rotated_.col(node_id).array();
   } else {
-    return above_sorted_.col(node_idx).array();
+    return above_sorted_.col(node_id).array();
   }
 }
 
-EigenArrayXb TidySubsplitDAG::AboveNode(size_t node_idx) {
-  return AboveNode(false, node_idx).max(AboveNode(true, node_idx));
+EigenArrayXb TidySubsplitDAG::AboveNode(size_t node_id) {
+  return AboveNode(false, node_id).max(AboveNode(true, node_id));
 }
 
-EigenArrayXb TidySubsplitDAG::AboveNode(bool rotated, size_t node_idx) {
+EigenArrayXb TidySubsplitDAG::AboveNode(bool rotated, size_t node_id) {
   if (rotated) {
-    return above_rotated_.row(node_idx).array();
+    return above_rotated_.row(node_id).array();
   } else {
-    return above_sorted_.row(node_idx).array();
+    return above_sorted_.row(node_id).array();
   }
 }
 
-// TODO change idx to id
-void TidySubsplitDAG::SetBelow(size_t parent_idx, bool parent_rotated,
-                               size_t child_idx) {
-  BelowNode(parent_rotated, parent_idx) =
-      BelowNode(parent_rotated, parent_idx).max(BelowNode(child_idx));
+void TidySubsplitDAG::SetBelow(size_t parent_id, bool parent_rotated, size_t child_id) {
+  BelowNode(parent_rotated, parent_id) =
+      BelowNode(parent_rotated, parent_id).max(BelowNode(child_id));
 }
 
 EigenArrayXbRef TidySubsplitDAG::DirtyVector(bool rotated) {
@@ -74,18 +72,18 @@ EigenArrayXbRef TidySubsplitDAG::DirtyVector(bool rotated) {
   }
 }
 
-bool TidySubsplitDAG::IsDirtyBelow(size_t node_idx, bool rotated) {
+bool TidySubsplitDAG::IsDirtyBelow(size_t node_id, bool rotated) {
   // We use `min` as a way of getting "and": we want to find if there are any dirty
   // node-clades below us.
-  return BelowNode(rotated, node_idx).min(DirtyVector(rotated)).maxCoeff();
+  return BelowNode(rotated, node_id).min(DirtyVector(rotated)).maxCoeff();
 }
 
-void TidySubsplitDAG::SetDirtyStrictlyAbove(size_t node_idx) {
+void TidySubsplitDAG::SetDirtyStrictlyAbove(size_t node_id) {
   for (const bool rotated : {false, true}) {
     EigenArrayXbRef dirty = DirtyVector(rotated);
-    EigenArrayXb to_make_dirty = AboveNode(rotated, node_idx);
+    EigenArrayXb to_make_dirty = AboveNode(rotated, node_id);
     // We are only dirtying things that are strictly above us.
-    to_make_dirty[node_idx] = false;
+    to_make_dirty[node_id] = false;
     // We use `max` as a way of getting "or": we want to maintain anything that's
     // already dirty as dirty, while adding all nodes strictly above us.
     dirty = dirty.max(to_make_dirty);

--- a/src/tidy_subsplit_dag.cpp
+++ b/src/tidy_subsplit_dag.cpp
@@ -59,11 +59,6 @@ EigenArrayXb TidySubsplitDAG::AboveNode(bool rotated, size_t node_id) {
   }
 }
 
-void TidySubsplitDAG::SetBelow(size_t parent_id, bool parent_rotated, size_t child_id) {
-  BelowNode(parent_rotated, parent_id) =
-      BelowNode(parent_rotated, parent_id).max(BelowNode(child_id));
-}
-
 EigenArrayXbRef TidySubsplitDAG::DirtyVector(bool rotated) {
   if (rotated) {
     return dirty_rotated_;
@@ -120,6 +115,19 @@ TidySubsplitDAG TidySubsplitDAG::TrivialExample() {
   return TidySubsplitDAG(3, {{topology, 1}});
 }
 
+TidySubsplitDAG TidySubsplitDAG::ManualTrivialExample() {
+  auto manual_dag = TidySubsplitDAG(5);
+
+  // The tree ((0,1)3,2)4:
+  // https://github.com/phylovi/libsbn/issues/307#issuecomment-766137769
+  manual_dag.SetBelow(3, true, 0);
+  manual_dag.SetBelow(3, false, 1);
+  manual_dag.SetBelow(4, true, 2);
+  manual_dag.SetBelow(4, false, 3);
+
+  return manual_dag;
+}
+
 TidySubsplitDAG TidySubsplitDAG::MotivatingExample() {
   auto topologies = Node::ExampleTopologies();
   return TidySubsplitDAG(4, {{topologies[3], 1}, {topologies[4], 1}});
@@ -149,3 +157,9 @@ std::string TidySubsplitDAG::RecordTraversal() {
       }));
   return result.str();
 }
+
+void TidySubsplitDAG::SetBelow(size_t parent_id, bool parent_rotated, size_t child_id) {
+  BelowNode(parent_rotated, parent_id) =
+      BelowNode(parent_rotated, parent_id).max(BelowNode(child_id));
+}
+

--- a/src/tidy_subsplit_dag.cpp
+++ b/src/tidy_subsplit_dag.cpp
@@ -92,20 +92,21 @@ void TidySubsplitDAG::SetClean() {
 }
 
 std::string EigenMatrixXbToString(EigenMatrixXb m) {
-  std::stringstream ss;
-  // I would have thought that we could just do ss << m, but this doesn't work.
+  std::stringstream string_stream;
+  // I would have thought that we could just do string_stream << m, but this doesn't
+  // work.
   for (size_t i = 0; i < m.rows(); i++) {
-    ss << m.row(i) << "\n";
+    string_stream << m.row(i) << "\n";
   }
-  return ss.str();
+  return string_stream.str();
 }
 
 std::string TidySubsplitDAG::AboveMatricesAsString() {
-  std::stringstream ss;
-  ss << "[\n"
-     << EigenMatrixXbToString(above_rotated_) << ", \n"
-     << EigenMatrixXbToString(above_sorted_) << "\n]";
-  return ss.str();
+  std::stringstream string_stream;
+  string_stream << "[\n"
+                << EigenMatrixXbToString(above_rotated_) << ", \n"
+                << EigenMatrixXbToString(above_sorted_) << "\n]";
+  return string_stream.str();
 }
 
 TidySubsplitDAG TidySubsplitDAG::TrivialExample() {

--- a/src/tidy_subsplit_dag.cpp
+++ b/src/tidy_subsplit_dag.cpp
@@ -10,13 +10,10 @@ TidySubsplitDAG::TidySubsplitDAG(EigenMatrixXb above) : above_(above){};
 TidySubsplitDAG::TidySubsplitDAG(const RootedTreeCollection &tree_collection)
     : SubsplitDAG(tree_collection) {}
 
-EigenArrayXbRef TidySubsplitDAG::AboveNode(size_t node_idx) {
+EigenArrayXbRef TidySubsplitDAG::BelowNode(size_t node_idx) {
   return above_.col(node_idx).array();
 }
 
-EigenRowArrayXbRef TidySubsplitDAG::BelowNode(size_t node_idx) {
-  // This block is a way of getting the node_idx'th row.
-  return above_.block(node_idx, 0, 1, above_.cols()).array();
-  // I don't know why we can't do this:
-  // return above_.row(node_idx).array();
+EigenArrayXb TidySubsplitDAG::AboveNode(size_t node_idx) {
+  return above_.row(node_idx).array();
 }

--- a/src/tidy_subsplit_dag.cpp
+++ b/src/tidy_subsplit_dag.cpp
@@ -149,4 +149,3 @@ std::string TidySubsplitDAG::RecordTraversal() {
       }));
   return result.str();
 }
-

--- a/src/tidy_subsplit_dag.cpp
+++ b/src/tidy_subsplit_dag.cpp
@@ -15,7 +15,23 @@ TidySubsplitDAG::TidySubsplitDAG(size_t node_count)
 
 TidySubsplitDAG::TidySubsplitDAG(size_t taxon_count,
                                  const Node::TopologyCounter &topology_counter)
-    : SubsplitDAG(taxon_count, topology_counter) {}
+    : SubsplitDAG(taxon_count, topology_counter) {
+  auto node_count = NodeCount();
+  above_sorted_ = EigenMatrixXb::Identity(node_count, node_count);
+  above_rotated_ = EigenMatrixXb::Identity(node_count, node_count);
+
+  DepthFirstWithAction(SubsplitDAGTraversalAction(
+      // BeforeNode
+      [](size_t node_id) {},
+      // AfterNode
+      [](size_t node_id) {},
+      // BeforeNodeClade
+      [](size_t node_id, bool rotated) {},
+      // VisitEdge
+      [this](size_t node_id, size_t child_id, bool rotated) {
+        SetBelow(node_id, rotated, child_id);
+      }));
+}
 
 EigenArrayXb TidySubsplitDAG::BelowNode(size_t node_idx) {
   return BelowNode(false, node_idx).max(BelowNode(true, node_idx));
@@ -41,15 +57,35 @@ EigenArrayXb TidySubsplitDAG::AboveNode(bool rotated, size_t node_idx) {
   }
 }
 
-void TidySubsplitDAG::SetBelow(size_t dst_idx, bool dst_rotated, size_t src_idx) {
-  BelowNode(dst_rotated, dst_idx) =
-      BelowNode(dst_rotated, dst_idx).max(BelowNode(src_idx));
+// TODO change idx to id
+void TidySubsplitDAG::SetBelow(size_t parent_idx, bool parent_rotated,
+                               size_t child_idx) {
+  BelowNode(parent_rotated, parent_idx) =
+      BelowNode(parent_rotated, parent_idx).max(BelowNode(child_idx));
+}
+
+std::string EigenMatrixXbToString(EigenMatrixXb m) {
+  std::stringstream ss;
+  // I would have thought that we could just do ss << m, but this doesn't work.
+  for (size_t i = 0; i < m.rows(); i++) {
+    ss << m.row(i) << "\n";
+  }
+  return ss.str();
+}
+
+std::string TidySubsplitDAG::AboveMatricesAsString() {
+  std::stringstream ss;
+  ss << "[\n"
+     << EigenMatrixXbToString(above_rotated_) << ", \n"
+     << EigenMatrixXbToString(above_sorted_) << "\n]";
+  return ss.str();
 }
 
 TidySubsplitDAG TidySubsplitDAG::TrivialExample() {
   // ((0,1),2)
   auto topology = Node::Join(Node::Join(Node::Leaf(0), Node::Leaf(1)), Node::Leaf(2));
   topology->Polish();
+  std::cout << topology->Newick(std::nullopt, std::nullopt, true) << std::endl;
   return TidySubsplitDAG(3, {{topology, 1}});
 }
 

--- a/src/tidy_subsplit_dag.cpp
+++ b/src/tidy_subsplit_dag.cpp
@@ -80,11 +80,13 @@ bool TidySubsplitDAG::IsDirtyBelow(size_t node_idx, bool rotated) {
   return BelowNode(rotated, node_idx).min(DirtyVector(rotated)).maxCoeff();
 }
 
-void TidySubsplitDAG::SetDirtyAbove(size_t node_idx, bool rotated) {
-  // We use `max` as a way of getting "or": we want to maintain anything that's already
-  // dirty as dirty, while adding all nodes above us.
-  EigenArrayXbRef dirty = DirtyVector(rotated);
-  dirty = dirty.max(AboveNode(rotated, node_idx));
+void TidySubsplitDAG::SetDirtyAbove(size_t node_idx) {
+  for (const bool rotated : {false, true}) {
+    EigenArrayXbRef dirty = DirtyVector(rotated);
+    // We use `max` as a way of getting "or": we want to maintain anything that's
+    // already dirty as dirty, while adding all nodes above us.
+    dirty = dirty.max(AboveNode(rotated, node_idx));
+  }
 }
 
 std::string EigenMatrixXbToString(EigenMatrixXb m) {

--- a/src/tidy_subsplit_dag.cpp
+++ b/src/tidy_subsplit_dag.cpp
@@ -22,7 +22,7 @@ TidySubsplitDAG::TidySubsplitDAG(size_t taxon_count,
   dirty_rotated_ = EigenArrayXb::Zero(node_count);
   dirty_sorted_ = EigenArrayXb::Zero(node_count);
 
-  DepthFirstWithAction(SubsplitDAGTraversalAction(
+  SubsplitDAG::DepthFirstWithAction(SubsplitDAGTraversalAction(
       // BeforeNode
       [](size_t node_id) {},
       // AfterNode

--- a/src/tidy_subsplit_dag.cpp
+++ b/src/tidy_subsplit_dag.cpp
@@ -1,0 +1,9 @@
+// Copyright 2019-2020 libsbn project contributors.
+// libsbn is free software under the GPLv3; see LICENSE file for details.
+
+#include "tidy_subsplit_dag.hpp"
+
+TidySubsplitDAG::TidySubsplitDAG() : SubsplitDAG() {}
+
+TidySubsplitDAG::TidySubsplitDAG(const RootedTreeCollection &tree_collection)
+    : SubsplitDAG(tree_collection) {}

--- a/src/tidy_subsplit_dag.cpp
+++ b/src/tidy_subsplit_dag.cpp
@@ -5,12 +5,17 @@
 
 TidySubsplitDAG::TidySubsplitDAG() : SubsplitDAG() {}
 
+// TODO something
 TidySubsplitDAG::TidySubsplitDAG(const RootedTreeCollection &tree_collection)
     : SubsplitDAG(tree_collection) {}
 
 TidySubsplitDAG::TidySubsplitDAG(size_t node_count)
     : above_sorted_(EigenMatrixXb::Identity(node_count, node_count)),
       above_rotated_(EigenMatrixXb::Identity(node_count, node_count)){};
+
+TidySubsplitDAG::TidySubsplitDAG(size_t taxon_count,
+                                 const Node::TopologyCounter &topology_counter)
+    : SubsplitDAG(taxon_count, topology_counter) {}
 
 EigenArrayXb TidySubsplitDAG::BelowNode(size_t node_idx) {
   return BelowNode(false, node_idx).max(BelowNode(true, node_idx));
@@ -40,3 +45,9 @@ void TidySubsplitDAG::SetBelow(size_t dst_idx, bool dst_rotated, size_t src_idx)
   BelowNode(dst_rotated, dst_idx) =
       BelowNode(dst_rotated, dst_idx).max(BelowNode(src_idx));
 }
+
+TidySubsplitDAG TidySubsplitDAG::MotivatingExample() {
+  auto topologies = Node::ExampleTopologies();
+  return TidySubsplitDAG(4, {{topologies[3], 1}, {topologies[4], 1}});
+}
+

--- a/src/tidy_subsplit_dag.cpp
+++ b/src/tidy_subsplit_dag.cpp
@@ -8,11 +8,11 @@ TidySubsplitDAG::TidySubsplitDAG() : SubsplitDAG() {}
 TidySubsplitDAG::TidySubsplitDAG(const RootedTreeCollection &tree_collection)
     : SubsplitDAG(tree_collection) {}
 
-EigenColArrayXbRef TidySubsplitDAG::AboveNode(size_t node_idx) {
+EigenArrayXbRef TidySubsplitDAG::AboveNode(size_t node_idx) {
   return above_.col(node_idx).array();
 }
 
-EigenRowArrayXbRef TidySubsplitDAG::BelowNode(size_t node_idx) {
+EigenArrayXbRef TidySubsplitDAG::BelowNode(size_t node_idx) {
   return above_.block(node_idx, 1, 1, above_.cols()).array();
   // return above_.row(node_idx).array();
 }

--- a/src/tidy_subsplit_dag.cpp
+++ b/src/tidy_subsplit_dag.cpp
@@ -17,3 +17,14 @@ EigenArrayXbRef TidySubsplitDAG::BelowNode(size_t node_idx) {
 EigenArrayXb TidySubsplitDAG::AboveNode(size_t node_idx) {
   return above_.row(node_idx).array();
 }
+
+void TidySubsplitDAG::JoinBelow(size_t dst, size_t src1, size_t src2) {
+  BelowNode(dst) = BelowNode(dst).max(BelowNode(src1));
+  BelowNode(dst) = BelowNode(dst).max(BelowNode(src2));
+}
+
+void TidySubsplitDAG::PrintBelowMatrix() {
+  for (size_t i = 0; i < above_.rows(); i++) {
+    std::cout << above_.row(i) << std::endl;
+  }
+}

--- a/src/tidy_subsplit_dag.cpp
+++ b/src/tidy_subsplit_dag.cpp
@@ -46,6 +46,13 @@ void TidySubsplitDAG::SetBelow(size_t dst_idx, bool dst_rotated, size_t src_idx)
       BelowNode(dst_rotated, dst_idx).max(BelowNode(src_idx));
 }
 
+TidySubsplitDAG TidySubsplitDAG::TrivialExample() {
+  // ((0,1),2)
+  auto topology = Node::Join(Node::Join(Node::Leaf(0), Node::Leaf(1)), Node::Leaf(2));
+  topology->Polish();
+  return TidySubsplitDAG(3, {{topology, 1}});
+}
+
 TidySubsplitDAG TidySubsplitDAG::MotivatingExample() {
   auto topologies = Node::ExampleTopologies();
   return TidySubsplitDAG(4, {{topologies[3], 1}, {topologies[4], 1}});

--- a/src/tidy_subsplit_dag.cpp
+++ b/src/tidy_subsplit_dag.cpp
@@ -163,4 +163,3 @@ void TidySubsplitDAG::SetBelow(size_t parent_id, bool parent_rotated, size_t chi
   BelowNode(parent_rotated, parent_id) =
       BelowNode(parent_rotated, parent_id).max(BelowNode(child_id));
 }
-

--- a/src/tidy_subsplit_dag.cpp
+++ b/src/tidy_subsplit_dag.cpp
@@ -5,7 +5,8 @@
 
 TidySubsplitDAG::TidySubsplitDAG() : SubsplitDAG() {}
 
-TidySubsplitDAG::TidySubsplitDAG(EigenMatrixXb above) : above_(above){};
+TidySubsplitDAG::TidySubsplitDAG(size_t node_count)
+    : above_(EigenMatrixXb::Identity(node_count, node_count)){};
 
 TidySubsplitDAG::TidySubsplitDAG(const RootedTreeCollection &tree_collection)
     : SubsplitDAG(tree_collection) {}

--- a/src/tidy_subsplit_dag.cpp
+++ b/src/tidy_subsplit_dag.cpp
@@ -85,7 +85,6 @@ TidySubsplitDAG TidySubsplitDAG::TrivialExample() {
   // ((0,1),2)
   auto topology = Node::Join(Node::Join(Node::Leaf(0), Node::Leaf(1)), Node::Leaf(2));
   topology->Polish();
-  std::cout << topology->Newick(std::nullopt, std::nullopt, true) << std::endl;
   return TidySubsplitDAG(3, {{topology, 1}});
 }
 

--- a/src/tidy_subsplit_dag.cpp
+++ b/src/tidy_subsplit_dag.cpp
@@ -47,11 +47,11 @@ EigenArrayXbRef TidySubsplitDAG::BelowNode(bool rotated, size_t node_id) {
   }
 }
 
-EigenArrayXb TidySubsplitDAG::AboveNode(size_t node_id) {
+EigenArrayXb TidySubsplitDAG::AboveNode(size_t node_id) const {
   return AboveNode(false, node_id).max(AboveNode(true, node_id));
 }
 
-EigenArrayXb TidySubsplitDAG::AboveNode(bool rotated, size_t node_id) {
+EigenArrayXb TidySubsplitDAG::AboveNode(bool rotated, size_t node_id) const {
   if (rotated) {
     return above_rotated_.row(node_id).array();
   } else {
@@ -101,7 +101,7 @@ std::string EigenMatrixXbToString(EigenMatrixXb m) {
   return string_stream.str();
 }
 
-std::string TidySubsplitDAG::AboveMatricesAsString() {
+std::string TidySubsplitDAG::AboveMatricesAsString() const {
   std::stringstream string_stream;
   string_stream << "[\n"
                 << EigenMatrixXbToString(above_rotated_) << ", \n"

--- a/src/tidy_subsplit_dag.cpp
+++ b/src/tidy_subsplit_dag.cpp
@@ -89,6 +89,11 @@ void TidySubsplitDAG::SetDirtyAbove(size_t node_idx) {
   }
 }
 
+void TidySubsplitDAG::SetClean() {
+  dirty_rotated_.setConstant(false);
+  dirty_sorted_.setConstant(false);
+}
+
 std::string EigenMatrixXbToString(EigenMatrixXb m) {
   std::stringstream ss;
   // I would have thought that we could just do ss << m, but this doesn't work.
@@ -120,6 +125,7 @@ TidySubsplitDAG TidySubsplitDAG::MotivatingExample() {
 
 std::string TidySubsplitDAG::RecordTraversal() {
   std::stringstream result;
+  size_t counter = 0;
   DepthFirstWithAction(TidySubsplitDAGTraversalAction(
       // BeforeNode
       [](size_t node_id) {},
@@ -128,13 +134,15 @@ std::string TidySubsplitDAG::RecordTraversal() {
       // BeforeNodeClade
       [](size_t node_id, bool rotated) {},
       // ModifyEdge
-      [this, &result](size_t node_id, size_t child_id, bool rotated) {
-        result << "modifying: ";
+      [this, &result, &counter](size_t node_id, size_t child_id, bool rotated) {
+        result << counter << " modifying: ";
+        counter++;
         result << node_id << ", " << child_id << ", " << rotated << "\n";
       },
       // UpdateEdge
-      [this, &result](size_t node_id, size_t child_id, bool rotated) {
-        result << "updating: ";
+      [this, &result, &counter](size_t node_id, size_t child_id, bool rotated) {
+        result << counter << " updating: ";
+        counter++;
         result << node_id << ", " << child_id << ", " << rotated << "\n";
       }));
   return result.str();

--- a/src/tidy_subsplit_dag.cpp
+++ b/src/tidy_subsplit_dag.cpp
@@ -5,6 +5,8 @@
 
 TidySubsplitDAG::TidySubsplitDAG() : SubsplitDAG() {}
 
+TidySubsplitDAG::TidySubsplitDAG(EigenMatrixXb above) : above_(above){};
+
 TidySubsplitDAG::TidySubsplitDAG(const RootedTreeCollection &tree_collection)
     : SubsplitDAG(tree_collection) {}
 
@@ -13,6 +15,8 @@ EigenArrayXbRef TidySubsplitDAG::AboveNode(size_t node_idx) {
 }
 
 EigenArrayXbRef TidySubsplitDAG::BelowNode(size_t node_idx) {
-  return above_.block(node_idx, 1, 1, above_.cols()).array();
+  // This block is a way of getting the node_idx'th row.
+  return above_.block(node_idx, 0, 1, above_.cols()).array();
+  // I don't know why we can't do this:
   // return above_.row(node_idx).array();
 }

--- a/src/tidy_subsplit_dag.cpp
+++ b/src/tidy_subsplit_dag.cpp
@@ -93,6 +93,7 @@ void TidySubsplitDAG::SetDirtyStrictlyAbove(size_t node_idx) {
 }
 
 void TidySubsplitDAG::SetClean() {
+  updating_below_ = std::nullopt;
   dirty_rotated_.setConstant(false);
   dirty_sorted_.setConstant(false);
 }

--- a/src/tidy_subsplit_dag.cpp
+++ b/src/tidy_subsplit_dag.cpp
@@ -7,3 +7,12 @@ TidySubsplitDAG::TidySubsplitDAG() : SubsplitDAG() {}
 
 TidySubsplitDAG::TidySubsplitDAG(const RootedTreeCollection &tree_collection)
     : SubsplitDAG(tree_collection) {}
+
+EigenColArrayXbRef TidySubsplitDAG::AboveNode(size_t node_idx) {
+  return above_.col(node_idx).array();
+}
+
+EigenRowArrayXbRef TidySubsplitDAG::BelowNode(size_t node_idx) {
+  return above_.block(node_idx, 1, 1, above_.cols()).array();
+  // return above_.row(node_idx).array();
+}

--- a/src/tidy_subsplit_dag.cpp
+++ b/src/tidy_subsplit_dag.cpp
@@ -40,12 +40,6 @@ EigenArrayXb TidySubsplitDAG::BelowNode(size_t node_idx) {
 }
 
 EigenArrayXbRef TidySubsplitDAG::BelowNode(bool rotated, size_t node_idx) {
-  if (node_idx >= above_rotated_.cols()) {
-    std::cout << ToDot() << std::endl;
-    std::cout << AboveMatricesAsString() << std::endl;
-    std::cout << above_rotated_.cols() << std::endl;
-  }
-  Assert(node_idx < above_rotated_.cols(), "BelowNode: node_idx too big.");
   if (rotated) {
     return above_rotated_.col(node_idx).array();
   } else {

--- a/src/tidy_subsplit_dag.cpp
+++ b/src/tidy_subsplit_dag.cpp
@@ -118,3 +118,25 @@ TidySubsplitDAG TidySubsplitDAG::MotivatingExample() {
   return TidySubsplitDAG(4, {{topologies[3], 1}, {topologies[4], 1}});
 }
 
+std::string TidySubsplitDAG::RecordTraversal() {
+  std::stringstream result;
+  DepthFirstWithAction(TidySubsplitDAGTraversalAction(
+      // BeforeNode
+      [](size_t node_id) {},
+      // AfterNode
+      [](size_t node_id) {},
+      // BeforeNodeClade
+      [](size_t node_id, bool rotated) {},
+      // ModifyEdge
+      [this, &result](size_t node_id, size_t child_id, bool rotated) {
+        result << "modifying: ";
+        result << node_id << ", " << child_id << ", " << rotated << "\n";
+      },
+      // UpdateEdge
+      [this, &result](size_t node_id, size_t child_id, bool rotated) {
+        result << "updating: ";
+        result << node_id << ", " << child_id << ", " << rotated << "\n";
+      }));
+  return result.str();
+}
+

--- a/src/tidy_subsplit_dag.cpp
+++ b/src/tidy_subsplit_dag.cpp
@@ -14,7 +14,7 @@ EigenArrayXbRef TidySubsplitDAG::AboveNode(size_t node_idx) {
   return above_.col(node_idx).array();
 }
 
-EigenArrayXbRef TidySubsplitDAG::BelowNode(size_t node_idx) {
+EigenRowArrayXbRef TidySubsplitDAG::BelowNode(size_t node_idx) {
   // This block is a way of getting the node_idx'th row.
   return above_.block(node_idx, 0, 1, above_.cols()).array();
   // I don't know why we can't do this:

--- a/src/tidy_subsplit_dag.cpp
+++ b/src/tidy_subsplit_dag.cpp
@@ -125,24 +125,24 @@ TidySubsplitDAG TidySubsplitDAG::MotivatingExample() {
 
 std::string TidySubsplitDAG::RecordTraversal() {
   std::stringstream result;
-  size_t counter = 0;
+  result << std::boolalpha;
   DepthFirstWithAction(TidySubsplitDAGTraversalAction(
       // BeforeNode
       [](size_t node_id) {},
       // AfterNode
       [](size_t node_id) {},
       // BeforeNodeClade
-      [](size_t node_id, bool rotated) {},
+      [&result](size_t node_id, bool rotated) {
+        result << "descending along " << node_id << ", " << rotated << "\n";
+      },
       // ModifyEdge
-      [this, &result, &counter](size_t node_id, size_t child_id, bool rotated) {
-        result << counter << " modifying: ";
-        counter++;
+      [this, &result](size_t node_id, size_t child_id, bool rotated) {
+        result << "modifying: ";
         result << node_id << ", " << child_id << ", " << rotated << "\n";
       },
       // UpdateEdge
-      [this, &result, &counter](size_t node_id, size_t child_id, bool rotated) {
-        result << counter << " updating: ";
-        counter++;
+      [this, &result](size_t node_id, size_t child_id, bool rotated) {
+        result << "updating:  ";
         result << node_id << ", " << child_id << ", " << rotated << "\n";
       }));
   return result.str();

--- a/src/tidy_subsplit_dag.cpp
+++ b/src/tidy_subsplit_dag.cpp
@@ -80,12 +80,15 @@ bool TidySubsplitDAG::IsDirtyBelow(size_t node_idx, bool rotated) {
   return BelowNode(rotated, node_idx).min(DirtyVector(rotated)).maxCoeff();
 }
 
-void TidySubsplitDAG::SetDirtyAbove(size_t node_idx) {
+void TidySubsplitDAG::SetDirtyStrictlyAbove(size_t node_idx) {
   for (const bool rotated : {false, true}) {
     EigenArrayXbRef dirty = DirtyVector(rotated);
+    EigenArrayXb to_make_dirty = AboveNode(rotated, node_idx);
+    // We are only dirtying things that are strictly above us.
+    to_make_dirty[node_idx] = false;
     // We use `max` as a way of getting "or": we want to maintain anything that's
-    // already dirty as dirty, while adding all nodes above us.
-    dirty = dirty.max(AboveNode(rotated, node_idx));
+    // already dirty as dirty, while adding all nodes strictly above us.
+    dirty = dirty.max(to_make_dirty);
   }
 }
 

--- a/src/tidy_subsplit_dag.cpp
+++ b/src/tidy_subsplit_dag.cpp
@@ -5,9 +5,9 @@
 
 TidySubsplitDAG::TidySubsplitDAG() : SubsplitDAG() {}
 
-// TODO something
 TidySubsplitDAG::TidySubsplitDAG(const RootedTreeCollection &tree_collection)
-    : SubsplitDAG(tree_collection) {}
+    : TidySubsplitDAG(tree_collection.TaxonCount(), tree_collection.TopologyCounter()) {
+}
 
 TidySubsplitDAG::TidySubsplitDAG(size_t node_count)
     : above_sorted_(EigenMatrixXb::Identity(node_count, node_count)),
@@ -40,6 +40,12 @@ EigenArrayXb TidySubsplitDAG::BelowNode(size_t node_idx) {
 }
 
 EigenArrayXbRef TidySubsplitDAG::BelowNode(bool rotated, size_t node_idx) {
+  if (node_idx >= above_rotated_.cols()) {
+    std::cout << ToDot() << std::endl;
+    std::cout << AboveMatricesAsString() << std::endl;
+    std::cout << above_rotated_.cols() << std::endl;
+  }
+  Assert(node_idx < above_rotated_.cols(), "BelowNode: node_idx too big.");
   if (rotated) {
     return above_rotated_.col(node_idx).array();
   } else {
@@ -130,7 +136,7 @@ TidySubsplitDAG TidySubsplitDAG::MotivatingExample() {
 std::string TidySubsplitDAG::RecordTraversal() {
   std::stringstream result;
   result << std::boolalpha;
-  DepthFirstWithAction(TidySubsplitDAGTraversalAction(
+  DepthFirstWithTidyAction(TidySubsplitDAGTraversalAction(
       // BeforeNode
       [](size_t node_id) {},
       // AfterNode

--- a/src/tidy_subsplit_dag.hpp
+++ b/src/tidy_subsplit_dag.hpp
@@ -11,6 +11,8 @@
 class TidySubsplitDAG : public SubsplitDAG {
  public:
   TidySubsplitDAG();
+  // This constructor is really just meant for testing.
+  explicit TidySubsplitDAG(EigenMatrixXb above);
   explicit TidySubsplitDAG(const RootedTreeCollection &tree_collection);
 
   EigenArrayXbRef AboveNode(size_t node_idx);
@@ -20,5 +22,28 @@ class TidySubsplitDAG : public SubsplitDAG {
   // above_.(i,j) is true if i is above j, otherwise it's false.
   EigenMatrixXb above_;
 };
+
+#ifdef DOCTEST_LIBRARY_INCLUDED
+TEST_CASE("TidySubsplitDAG: slicing") {
+  EigenMatrixXb above(3, 3);
+  above.setConstant(false);
+  above << true, false, true,  //
+      false, true, true,       //
+      false, false, false;
+  // std::cout << GenericToString(above) << std::endl;
+  auto dag = TidySubsplitDAG(above);
+  // AboveNode is working
+  std::cout << GenericToString(dag.AboveNode(0));
+  std::cout << GenericToString(dag.AboveNode(1));
+  std::cout << GenericToString(dag.AboveNode(2));
+  std::cout << std::endl;
+  // BelowNode is not
+  std::cout << GenericToString(dag.BelowNode(0));
+  std::cout << GenericToString(dag.BelowNode(1));
+  std::cout << GenericToString(dag.BelowNode(2));
+  CHECK_EQ(GenericToString(dag.AboveNode(1)), "[0, 1, 0]\n");
+  CHECK_EQ(GenericToString(dag.BelowNode(1)), "[0, 1, 1]\n");
+}
+#endif  // DOCTEST_LIBRARY_INCLUDED
 
 #endif  // SRC_TIDY_SUBSPLIT_DAG_HPP_

--- a/src/tidy_subsplit_dag.hpp
+++ b/src/tidy_subsplit_dag.hpp
@@ -1,0 +1,17 @@
+// Copyright 2019-2020 libsbn project contributors.
+// libsbn is free software under the GPLv3; see LICENSE file for details.
+//
+// A "tidy" subsplit DAG has a notion of clean and dirty vectors.
+
+#ifndef SRC_TIDY_SUBSPLIT_DAG_HPP_
+#define SRC_TIDY_SUBSPLIT_DAG_HPP_
+
+#include "subsplit_dag.hpp"
+
+class TidySubsplitDAG : public SubsplitDAG {
+ public:
+  TidySubsplitDAG();
+  explicit TidySubsplitDAG(const RootedTreeCollection &tree_collection);
+};
+
+#endif  // SRC_TIDY_SUBSPLIT_DAG_HPP_

--- a/src/tidy_subsplit_dag.hpp
+++ b/src/tidy_subsplit_dag.hpp
@@ -18,7 +18,8 @@ class TidySubsplitDAG : public SubsplitDAG {
   // What nodes are above or below the specified node? We consider a node to be both
   // above and below itself (this just happens to be handy for the implementation).
   EigenArrayXb BelowNode(size_t node_idx);
-  // TODO let's change to rotated second. It's a subsplit clade.
+  // These use a different convention of rotated, then node idx, reflecting that we are
+  // asking the question "which `rotated` nodes are above node_idx"?
   EigenArrayXbRef BelowNode(bool rotated, size_t node_idx);
   EigenArrayXb AboveNode(size_t node_idx);
   EigenArrayXb AboveNode(bool rotated, size_t node_idx);

--- a/src/tidy_subsplit_dag.hpp
+++ b/src/tidy_subsplit_dag.hpp
@@ -15,8 +15,11 @@ class TidySubsplitDAG : public SubsplitDAG {
   explicit TidySubsplitDAG(EigenMatrixXb above);
   explicit TidySubsplitDAG(const RootedTreeCollection &tree_collection);
 
-  EigenArrayXb AboveNode(size_t node_idx);
   EigenArrayXbRef BelowNode(size_t node_idx);
+  EigenArrayXb AboveNode(size_t node_idx);
+  void JoinBelow(size_t dst, size_t src1, size_t src2);
+
+  void PrintBelowMatrix();
 
  private:
   // above_.(i,j) is true if i is above j, otherwise it's false.
@@ -25,22 +28,14 @@ class TidySubsplitDAG : public SubsplitDAG {
 
 #ifdef DOCTEST_LIBRARY_INCLUDED
 TEST_CASE("TidySubsplitDAG: slicing") {
-  EigenMatrixXb above(3, 3);
-  above.setConstant(false);
-  above << true, false, true,  //
-      false, true, true,       //
-      false, false, false;
-  // std::cout << GenericToString(above) << std::endl;
+  EigenMatrixXb above(5, 5);
+  above.setIdentity();
   auto dag = TidySubsplitDAG(above);
-  // AboveNode is working
-  std::cout << GenericToString(dag.AboveNode(0));
-  std::cout << GenericToString(dag.AboveNode(1));
-  std::cout << GenericToString(dag.AboveNode(2));
-  std::cout << std::endl;
-  // BelowNode is not
-  std::cout << GenericToString(dag.BelowNode(0));
-  std::cout << GenericToString(dag.BelowNode(1));
-  std::cout << GenericToString(dag.BelowNode(2));
+
+  dag.JoinBelow(1, 0, 2);
+  dag.JoinBelow(3, 1, 4);
+
+  dag.PrintBelowMatrix();
   // CHECK_EQ(GenericToString(dag.AboveNode(1)), "[0, 1, 0]\n");
   // CHECK_EQ(GenericToString(dag.BelowNode(1)), "[0, 1, 1]\n");
 }

--- a/src/tidy_subsplit_dag.hpp
+++ b/src/tidy_subsplit_dag.hpp
@@ -115,7 +115,7 @@ class TidySubsplitDAG : public SubsplitDAG {
       // We have completed updating our original goal of updating, and can turn off
       // updating mode.
       updating_below_ = std::nullopt;
-      }
+    }
   };
 
   // Perform edge modification below this node clade, dirtying and cleaning up as

--- a/src/tidy_subsplit_dag.hpp
+++ b/src/tidy_subsplit_dag.hpp
@@ -49,10 +49,11 @@ TEST_CASE("TidySubsplitDAG: slicing") {
   auto manual_dag = TidySubsplitDAG(5);
 
   // The tree ((0,1)3,2)4:
+  // https://github.com/phylovi/libsbn/issues/307#issuecomment-766137769
   manual_dag.SetBelow(3, true, 0);
   manual_dag.SetBelow(3, false, 1);
-  manual_dag.SetBelow(4, true, 3);
-  manual_dag.SetBelow(4, false, 2);
+  manual_dag.SetBelow(4, true, 2);
+  manual_dag.SetBelow(4, false, 3);
 
   CHECK_EQ(GenericToString(manual_dag.AboveNode(0)), "[1, 0, 0, 1, 1]\n");
   CHECK_EQ(GenericToString(manual_dag.AboveNode(1)), "[0, 1, 0, 1, 1]\n");
@@ -61,8 +62,10 @@ TEST_CASE("TidySubsplitDAG: slicing") {
   CHECK_EQ(GenericToString(manual_dag.AboveNode(4)), "[0, 0, 0, 0, 1]\n");
 
   auto trivial_dag = TidySubsplitDAG::TrivialExample();
-  std::cout << trivial_dag.AboveMatricesAsString() << std::endl;
-  std::cout << trivial_dag.ToDot() << std::endl;
+  CHECK_EQ(trivial_dag.AboveMatricesAsString(), manual_dag.AboveMatricesAsString());
+
+  auto motivating_dag = TidySubsplitDAG::MotivatingExample();
+  std::cout << motivating_dag.ToDot() << std::endl;
 }
 #endif  // DOCTEST_LIBRARY_INCLUDED
 

--- a/src/tidy_subsplit_dag.hpp
+++ b/src/tidy_subsplit_dag.hpp
@@ -16,7 +16,7 @@ class TidySubsplitDAG : public SubsplitDAG {
   explicit TidySubsplitDAG(const RootedTreeCollection &tree_collection);
 
   EigenArrayXbRef AboveNode(size_t node_idx);
-  EigenArrayXbRef BelowNode(size_t node_idx);
+  EigenRowArrayXbRef BelowNode(size_t node_idx);
 
  private:
   // above_.(i,j) is true if i is above j, otherwise it's false.

--- a/src/tidy_subsplit_dag.hpp
+++ b/src/tidy_subsplit_dag.hpp
@@ -27,10 +27,6 @@ class TidySubsplitDAG : public SubsplitDAG {
   EigenArrayXb AboveNode(size_t node_id);
   EigenArrayXb AboveNode(bool rotated, size_t node_id);
 
-  // Set the below matrix up to have the node at src_id below the subsplit-clade
-  // described by (dst_rotated, dst_id).
-  void SetBelow(size_t dst_id, bool dst_rotated, size_t src_id);
-
   EigenArrayXbRef DirtyVector(bool rotated);
   bool IsDirtyBelow(size_t node_id, bool rotated);
   void SetDirtyStrictlyAbove(size_t node_id);
@@ -41,6 +37,8 @@ class TidySubsplitDAG : public SubsplitDAG {
   // From ((0,1)2)
   // https://github.com/phylovi/libsbn/issues/307#issuecomment-766137769
   static TidySubsplitDAG TrivialExample();
+  // The same DAG, built by hand for the test.
+  static TidySubsplitDAG ManualTrivialExample();
   // From (0,(1,(2,3))) and ((0,(2,3)),1)
   // See https://github.com/phylovi/libsbn/issues/307#issuecomment-765901588
   // Update during #288 #321
@@ -168,11 +166,16 @@ class TidySubsplitDAG : public SubsplitDAG {
   EigenArrayXb dirty_sorted_;
 
   TidySubsplitDAG(size_t taxon_count, const Node::TopologyCounter &topology_counter);
+
+  // Set the below matrix up to have all of the nodes below src_id below the
+  // subsplit-clade described by (dst_rotated, dst_id). Meant to be used as part of a
+  // depth-first traversal.
+  void SetBelow(size_t dst_id, bool dst_rotated, size_t src_id);
 };
 
 #ifdef DOCTEST_LIBRARY_INCLUDED
 TEST_CASE("TidySubsplitDAG: slicing") {
-  auto manual_dag = TidySubsplitDAG(5);
+  auto manual_dag = ManualTrivialExample();
 
   // The tree ((0,1)3,2)4:
   // https://github.com/phylovi/libsbn/issues/307#issuecomment-766137769

--- a/src/tidy_subsplit_dag.hpp
+++ b/src/tidy_subsplit_dag.hpp
@@ -43,7 +43,7 @@ class TidySubsplitDAG : public SubsplitDAG {
   static TidySubsplitDAG TrivialExample();
   // From (0,(1,(2,3))) and ((0,(2,3)),1)
   // See https://github.com/phylovi/libsbn/issues/307#issuecomment-765901588
-  // Update during #288
+  // Update during #288 #321
   static TidySubsplitDAG MotivatingExample();
 
   std::string RecordTraversal();
@@ -75,7 +75,8 @@ class TidySubsplitDAG : public SubsplitDAG {
                                        size_t node_id,
                                        std::unordered_set<size_t> &visited_nodes) {
     action.BeforeNode(node_id);
-    // #288 Here we are doing true and then false (left and then right).
+    // #288 #321 Here we are doing true and then false (left and then right).
+    // This means that we get an update with the MotivatingExample as coded.
     DepthFirstWithTidyActionForNodeClade(action, node_id, true, visited_nodes);
     DepthFirstWithTidyActionForNodeClade(action, node_id, false, visited_nodes);
     action.AfterNode(node_id);
@@ -210,7 +211,7 @@ TEST_CASE("TidySubsplitDAG: slicing") {
            "[0, 0, 0, 0, 0, 1, 0, 1, 1]\n");
 
   motivating_dag.SetClean();
-  // #310 Add test for Tidy traversal.
+  // #321 Add test for Tidy traversal.
 }
 #endif  // DOCTEST_LIBRARY_INCLUDED
 

--- a/src/tidy_subsplit_dag.hpp
+++ b/src/tidy_subsplit_dag.hpp
@@ -24,20 +24,20 @@ class TidySubsplitDAG : public SubsplitDAG {
 
   // What nodes are above or below the specified node? We consider a node to be both
   // above and below itself (this just happens to be handy for the implementation).
-  EigenArrayXb BelowNode(size_t node_idx);
-  // These use a different convention of rotated, then node idx, reflecting that we are
-  // asking the question "which `rotated` nodes are above node_idx"?
-  EigenArrayXbRef BelowNode(bool rotated, size_t node_idx);
-  EigenArrayXb AboveNode(size_t node_idx);
-  EigenArrayXb AboveNode(bool rotated, size_t node_idx);
+  EigenArrayXb BelowNode(size_t node_id);
+  // These use a different convention of rotated, then node id, reflecting that we are
+  // asking the question "which `rotated` nodes are above node_id"?
+  EigenArrayXbRef BelowNode(bool rotated, size_t node_id);
+  EigenArrayXb AboveNode(size_t node_id);
+  EigenArrayXb AboveNode(bool rotated, size_t node_id);
 
-  // Set the below matrix up to have the node at src_idx below the subsplit-clade
-  // described by (dst_rotated, dst_idx).
-  void SetBelow(size_t dst_idx, bool dst_rotated, size_t src_idx);
+  // Set the below matrix up to have the node at src_id below the subsplit-clade
+  // described by (dst_rotated, dst_id).
+  void SetBelow(size_t dst_id, bool dst_rotated, size_t src_id);
 
   EigenArrayXbRef DirtyVector(bool rotated);
-  bool IsDirtyBelow(size_t node_idx, bool rotated);
-  void SetDirtyStrictlyAbove(size_t node_idx);
+  bool IsDirtyBelow(size_t node_id, bool rotated);
+  void SetDirtyStrictlyAbove(size_t node_id);
   void SetClean();
 
   std::string AboveMatricesAsString();

--- a/src/tidy_subsplit_dag.hpp
+++ b/src/tidy_subsplit_dag.hpp
@@ -2,6 +2,9 @@
 // libsbn is free software under the GPLv3; see LICENSE file for details.
 //
 // A "tidy" subsplit DAG has a notion of clean and dirty vectors.
+//
+// A node-clade is dirty iff there has been a calculation below that node-clade that
+// invalidates the p-hat PLV coming up into it.
 
 // TODO we could set things up so that the traversals are const, and we provide them
 // with a dirty vector. This would be better but more work.

--- a/src/tidy_subsplit_dag.hpp
+++ b/src/tidy_subsplit_dag.hpp
@@ -15,8 +15,8 @@ class TidySubsplitDAG : public SubsplitDAG {
   explicit TidySubsplitDAG(EigenMatrixXb above);
   explicit TidySubsplitDAG(const RootedTreeCollection &tree_collection);
 
-  EigenArrayXbRef AboveNode(size_t node_idx);
-  EigenRowArrayXbRef BelowNode(size_t node_idx);
+  EigenArrayXb AboveNode(size_t node_idx);
+  EigenArrayXbRef BelowNode(size_t node_idx);
 
  private:
   // above_.(i,j) is true if i is above j, otherwise it's false.
@@ -41,8 +41,8 @@ TEST_CASE("TidySubsplitDAG: slicing") {
   std::cout << GenericToString(dag.BelowNode(0));
   std::cout << GenericToString(dag.BelowNode(1));
   std::cout << GenericToString(dag.BelowNode(2));
-  CHECK_EQ(GenericToString(dag.AboveNode(1)), "[0, 1, 0]\n");
-  CHECK_EQ(GenericToString(dag.BelowNode(1)), "[0, 1, 1]\n");
+  // CHECK_EQ(GenericToString(dag.AboveNode(1)), "[0, 1, 0]\n");
+  // CHECK_EQ(GenericToString(dag.BelowNode(1)), "[0, 1, 1]\n");
 }
 #endif  // DOCTEST_LIBRARY_INCLUDED
 

--- a/src/tidy_subsplit_dag.hpp
+++ b/src/tidy_subsplit_dag.hpp
@@ -35,6 +35,7 @@ class TidySubsplitDAG : public SubsplitDAG {
   EigenArrayXbRef DirtyVector(bool rotated);
   bool IsDirtyBelow(size_t node_idx, bool rotated);
   void SetDirtyAbove(size_t node_idx);
+  void SetClean();
 
   std::string AboveMatricesAsString();
 
@@ -180,6 +181,7 @@ TEST_CASE("TidySubsplitDAG: slicing") {
   CHECK_EQ(GenericToString(motivating_dag.DirtyVector(false)),
            "[0, 0, 0, 0, 1, 1, 0, 1, 1]\n");
 
+  motivating_dag.SetClean();
   std::cout << motivating_dag.RecordTraversal();
 }
 #endif  // DOCTEST_LIBRARY_INCLUDED

--- a/src/tidy_subsplit_dag.hpp
+++ b/src/tidy_subsplit_dag.hpp
@@ -12,7 +12,7 @@ class TidySubsplitDAG : public SubsplitDAG {
  public:
   TidySubsplitDAG();
   // This constructor is really just meant for testing.
-  explicit TidySubsplitDAG(EigenMatrixXb above);
+  explicit TidySubsplitDAG(size_t node_count);
   explicit TidySubsplitDAG(const RootedTreeCollection &tree_collection);
 
   // What nodes are above or below the specified node? We consider a node to be both
@@ -30,9 +30,7 @@ class TidySubsplitDAG : public SubsplitDAG {
 
 #ifdef DOCTEST_LIBRARY_INCLUDED
 TEST_CASE("TidySubsplitDAG: slicing") {
-  EigenMatrixXb above(5, 5);
-  above.setIdentity();
-  auto dag = TidySubsplitDAG(above);
+  auto dag = TidySubsplitDAG(5);
 
   // The tree ((0,1)3,2)4:
   dag.JoinBelow(3, 0, 1);

--- a/src/tidy_subsplit_dag.hpp
+++ b/src/tidy_subsplit_dag.hpp
@@ -29,7 +29,7 @@ class TidySubsplitDAG : public SubsplitDAG {
 
   EigenArrayXbRef DirtyVector(bool rotated);
   bool IsDirtyBelow(size_t node_idx, bool rotated);
-  void SetDirtyAbove(size_t node_idx, bool rotated);
+  void SetDirtyAbove(size_t node_idx);
 
   std::string AboveMatricesAsString();
 
@@ -103,9 +103,11 @@ class TidySubsplitDAG : public SubsplitDAG {
   // above_sorted(i,j) is true iff i,false is above j.
   EigenMatrixXb above_sorted_;
 
-  // dirty_rotated_(i) is true iff i,true is dirty.
+  // dirty_rotated_(i) is true iff there has been a calculation below i,true that
+  // invalidates the p-hat PLV coming up into it.
   EigenArrayXb dirty_rotated_;
-  // dirty_sorted_(i) is true iff i,false is dirty.
+  // dirty_rotated_(i) is true iff there has been a calculation below i,false that
+  // invalidates the p-hat PLV coming up into it.
   EigenArrayXb dirty_sorted_;
 
   TidySubsplitDAG(size_t taxon_count, const Node::TopologyCounter &topology_counter);
@@ -144,6 +146,12 @@ TEST_CASE("TidySubsplitDAG: slicing") {
            "[0, 0, 1, 1, 1, 0, 0, 1, 0]\n");
   CHECK_EQ(GenericToString(motivating_dag.BelowNode(true, 7)),
            "[1, 0, 0, 0, 0, 0, 0, 1, 0]\n");
+
+  motivating_dag.SetDirtyAbove(4);
+  CHECK_EQ(GenericToString(motivating_dag.DirtyVector(true)),
+           "[0, 0, 0, 0, 1, 0, 1, 0, 0]\n");
+  CHECK_EQ(GenericToString(motivating_dag.DirtyVector(false)),
+           "[0, 0, 0, 0, 1, 1, 0, 1, 1]\n");
 }
 #endif  // DOCTEST_LIBRARY_INCLUDED
 

--- a/src/tidy_subsplit_dag.hpp
+++ b/src/tidy_subsplit_dag.hpp
@@ -26,9 +26,11 @@ class TidySubsplitDAG : public SubsplitDAG {
   // described by (dst_rotated, dst_idx).
   void SetBelow(size_t dst_idx, bool dst_rotated, size_t src_idx);
 
-  static TidySubsplitDAG TrivialExample();
+  std::string AboveMatricesAsString();
 
-  // (0,(1,(2,3))) and ((0,(2,3)),1)
+  // From ((0,1)2)
+  static TidySubsplitDAG TrivialExample();
+  // From (0,(1,(2,3))) and ((0,(2,3)),1)
   // See https://github.com/phylovi/libsbn/issues/307#issuecomment-765901588
   // Update during #288
   static TidySubsplitDAG MotivatingExample();
@@ -57,6 +59,10 @@ TEST_CASE("TidySubsplitDAG: slicing") {
   CHECK_EQ(GenericToString(manual_dag.AboveNode(2)), "[0, 0, 1, 0, 1]\n");
   CHECK_EQ(GenericToString(manual_dag.AboveNode(3)), "[0, 0, 0, 1, 1]\n");
   CHECK_EQ(GenericToString(manual_dag.AboveNode(4)), "[0, 0, 0, 0, 1]\n");
+
+  auto trivial_dag = TidySubsplitDAG::TrivialExample();
+  std::cout << trivial_dag.AboveMatricesAsString() << std::endl;
+  std::cout << trivial_dag.ToDot() << std::endl;
 }
 #endif  // DOCTEST_LIBRARY_INCLUDED
 

--- a/src/tidy_subsplit_dag.hpp
+++ b/src/tidy_subsplit_dag.hpp
@@ -29,6 +29,7 @@ class TidySubsplitDAG : public SubsplitDAG {
   std::string AboveMatricesAsString();
 
   // From ((0,1)2)
+  // https://github.com/phylovi/libsbn/issues/307#issuecomment-766137769
   static TidySubsplitDAG TrivialExample();
   // From (0,(1,(2,3))) and ((0,(2,3)),1)
   // See https://github.com/phylovi/libsbn/issues/307#issuecomment-765901588
@@ -65,7 +66,18 @@ TEST_CASE("TidySubsplitDAG: slicing") {
   CHECK_EQ(trivial_dag.AboveMatricesAsString(), manual_dag.AboveMatricesAsString());
 
   auto motivating_dag = TidySubsplitDAG::MotivatingExample();
-  std::cout << motivating_dag.ToDot() << std::endl;
+  CHECK_EQ(GenericToString(motivating_dag.AboveNode(false, 4)),
+           "[0, 0, 0, 0, 1, 1, 0, 1, 1]\n");
+  CHECK_EQ(GenericToString(motivating_dag.AboveNode(true, 4)),
+           "[0, 0, 0, 0, 1, 0, 1, 0, 0]\n");
+  CHECK_EQ(GenericToString(motivating_dag.AboveNode(false, 7)),
+           "[0, 0, 0, 0, 0, 0, 0, 1, 1]\n");
+  CHECK_EQ(GenericToString(motivating_dag.AboveNode(true, 7)),
+           "[0, 0, 0, 0, 0, 0, 0, 1, 0]\n");
+  CHECK_EQ(GenericToString(motivating_dag.BelowNode(false, 7)),
+           "[0, 0, 1, 1, 1, 0, 0, 1, 0]\n");
+  CHECK_EQ(GenericToString(motivating_dag.BelowNode(true, 7)),
+           "[1, 0, 0, 0, 0, 0, 0, 1, 0]\n");
 }
 #endif  // DOCTEST_LIBRARY_INCLUDED
 

--- a/src/tidy_subsplit_dag.hpp
+++ b/src/tidy_subsplit_dag.hpp
@@ -78,8 +78,8 @@ class TidySubsplitDAG : public SubsplitDAG {
   void DepthFirstWithActionForNode(const TraversalActionT &action, size_t node_id,
                                    std::unordered_set<size_t> &visited_nodes) {
     action.BeforeNode(node_id);
-    DepthFirstWithActionForNodeClade(action, node_id, false, visited_nodes);
     DepthFirstWithActionForNodeClade(action, node_id, true, visited_nodes);
+    DepthFirstWithActionForNodeClade(action, node_id, false, visited_nodes);
     action.AfterNode(node_id);
   };
 
@@ -95,8 +95,8 @@ class TidySubsplitDAG : public SubsplitDAG {
       if (IsDirtyBelow(node_id, rotated)) {
         for (const size_t child_id : node->GetLeafward(rotated)) {
           if (!GetDagNode(child_id)->IsLeaf()) {
-            DepthFirstWithActionForNodeClade(action, child_id, false, visited_nodes);
             DepthFirstWithActionForNodeClade(action, child_id, true, visited_nodes);
+            DepthFirstWithActionForNodeClade(action, child_id, false, visited_nodes);
             action.AfterNode(child_id);
           }
           action.UpdateEdge(node_id, child_id, rotated);

--- a/src/tidy_subsplit_dag.hpp
+++ b/src/tidy_subsplit_dag.hpp
@@ -5,6 +5,10 @@
 //
 // A node-clade is dirty iff there has been a calculation below that node-clade that
 // invalidates the p-hat PLV coming up into it.
+//
+// #321 It would be nice to make the traversals const, which would require us to supply
+// dirty and clean vectors, and updating_below_ as variables. Perhaps these could be
+// part of the Action?
 
 #ifndef SRC_TIDY_SUBSPLIT_DAG_HPP_
 #define SRC_TIDY_SUBSPLIT_DAG_HPP_
@@ -22,15 +26,15 @@ class TidySubsplitDAG : public SubsplitDAG {
   // These use a different convention of rotated, then node id, reflecting that we are
   // asking the question "which `rotated` nodes are above node_id"?
   EigenArrayXbRef BelowNode(bool rotated, size_t node_id);
-  EigenArrayXb AboveNode(size_t node_id);
-  EigenArrayXb AboveNode(bool rotated, size_t node_id);
+  EigenArrayXb AboveNode(size_t node_id) const;
+  EigenArrayXb AboveNode(bool rotated, size_t node_id) const;
 
   EigenArrayXbRef DirtyVector(bool rotated);
   bool IsDirtyBelow(size_t node_id, bool rotated);
   void SetDirtyStrictlyAbove(size_t node_id);
   void SetClean();
 
-  std::string AboveMatricesAsString();
+  std::string AboveMatricesAsString() const;
 
   // From ((0,1)2)
   // https://github.com/phylovi/libsbn/issues/307#issuecomment-766137769

--- a/src/tidy_subsplit_dag.hpp
+++ b/src/tidy_subsplit_dag.hpp
@@ -46,11 +46,16 @@ class TidySubsplitDAG : public SubsplitDAG {
 
   // Apply a TidySubsplitDAGTraversalAction via a depth first traversal. Do not visit
   // leaf nodes.
-  // We assume that ModifyEdge leaves (node_id, rotated) in a clean state.
+  // We assume that ModifyEdge leaves (node_id, rotated) in a clean state, however, each
+  // ModifyEdge dirties all of the nodes above it. These nodes must be cleaned by
+  // UpdateEdge before they are ready to be used. See TidySubslitDAGTraversalAction for
+  // more details.
+  //
   // Applied to a given node, we:
   // * Apply BeforeNode
   // * For each of the clades of the node, we:
-  //     * Descend into each clade, cleaning up with UpdateEdge as needed.
+  //     * Descend into each clade, cleaning up the sister clade with UpdateEdge as
+  //     needed.
   //     * Apply BeforeNodeClade
   //     * For each edge descending from that clade, we:
   //         * Recur into the child node of the clade if it is not a leaf

--- a/src/tidy_subsplit_dag.hpp
+++ b/src/tidy_subsplit_dag.hpp
@@ -12,6 +12,13 @@ class TidySubsplitDAG : public SubsplitDAG {
  public:
   TidySubsplitDAG();
   explicit TidySubsplitDAG(const RootedTreeCollection &tree_collection);
+
+  EigenColArrayXbRef AboveNode(size_t node_idx);
+  EigenRowArrayXbRef BelowNode(size_t node_idx);
+
+ private:
+  // above_.(i,j) is true if i is above j, otherwise it's false.
+  EigenMatrixXb above_;
 };
 
 #endif  // SRC_TIDY_SUBSPLIT_DAG_HPP_

--- a/src/tidy_subsplit_dag.hpp
+++ b/src/tidy_subsplit_dag.hpp
@@ -26,11 +26,18 @@ class TidySubsplitDAG : public SubsplitDAG {
   // described by (dst_rotated, dst_idx).
   void SetBelow(size_t dst_idx, bool dst_rotated, size_t src_idx);
 
+  // (0,(1,(2,3))) and ((0,(2,3)),1)
+  // See https://github.com/phylovi/libsbn/issues/307#issuecomment-765901588
+  // Update during #288
+  static TidySubsplitDAG MotivatingExample();
+
  private:
   // above_rotated_.(i,j) is true iff i,true is above j.
   EigenMatrixXb above_rotated_;
   // above_sorted.(i,j) is true iff i,false is above j.
   EigenMatrixXb above_sorted_;
+
+  TidySubsplitDAG(size_t taxon_count, const Node::TopologyCounter &topology_counter);
 };
 
 #ifdef DOCTEST_LIBRARY_INCLUDED

--- a/src/tidy_subsplit_dag.hpp
+++ b/src/tidy_subsplit_dag.hpp
@@ -26,6 +26,8 @@ class TidySubsplitDAG : public SubsplitDAG {
   // described by (dst_rotated, dst_idx).
   void SetBelow(size_t dst_idx, bool dst_rotated, size_t src_idx);
 
+  static TidySubsplitDAG TrivialExample();
+
   // (0,(1,(2,3))) and ((0,(2,3)),1)
   // See https://github.com/phylovi/libsbn/issues/307#issuecomment-765901588
   // Update during #288
@@ -42,19 +44,19 @@ class TidySubsplitDAG : public SubsplitDAG {
 
 #ifdef DOCTEST_LIBRARY_INCLUDED
 TEST_CASE("TidySubsplitDAG: slicing") {
-  auto dag = TidySubsplitDAG(5);
+  auto manual_dag = TidySubsplitDAG(5);
 
   // The tree ((0,1)3,2)4:
-  dag.SetBelow(3, true, 0);
-  dag.SetBelow(3, false, 1);
-  dag.SetBelow(4, true, 3);
-  dag.SetBelow(4, false, 2);
+  manual_dag.SetBelow(3, true, 0);
+  manual_dag.SetBelow(3, false, 1);
+  manual_dag.SetBelow(4, true, 3);
+  manual_dag.SetBelow(4, false, 2);
 
-  CHECK_EQ(GenericToString(dag.AboveNode(0)), "[1, 0, 0, 1, 1]\n");
-  CHECK_EQ(GenericToString(dag.AboveNode(1)), "[0, 1, 0, 1, 1]\n");
-  CHECK_EQ(GenericToString(dag.AboveNode(2)), "[0, 0, 1, 0, 1]\n");
-  CHECK_EQ(GenericToString(dag.AboveNode(3)), "[0, 0, 0, 1, 1]\n");
-  CHECK_EQ(GenericToString(dag.AboveNode(4)), "[0, 0, 0, 0, 1]\n");
+  CHECK_EQ(GenericToString(manual_dag.AboveNode(0)), "[1, 0, 0, 1, 1]\n");
+  CHECK_EQ(GenericToString(manual_dag.AboveNode(1)), "[0, 1, 0, 1, 1]\n");
+  CHECK_EQ(GenericToString(manual_dag.AboveNode(2)), "[0, 0, 1, 0, 1]\n");
+  CHECK_EQ(GenericToString(manual_dag.AboveNode(3)), "[0, 0, 0, 1, 1]\n");
+  CHECK_EQ(GenericToString(manual_dag.AboveNode(4)), "[0, 0, 0, 0, 1]\n");
 }
 #endif  // DOCTEST_LIBRARY_INCLUDED
 

--- a/src/tidy_subsplit_dag.hpp
+++ b/src/tidy_subsplit_dag.hpp
@@ -15,6 +15,8 @@ class TidySubsplitDAG : public SubsplitDAG {
   explicit TidySubsplitDAG(EigenMatrixXb above);
   explicit TidySubsplitDAG(const RootedTreeCollection &tree_collection);
 
+  // What nodes are above or below the specified node? We consider a node to be both
+  // above and below itself (this just happens to be handy for the implementation).
   EigenArrayXbRef BelowNode(size_t node_idx);
   EigenArrayXb AboveNode(size_t node_idx);
   void JoinBelow(size_t dst, size_t src1, size_t src2);
@@ -32,12 +34,15 @@ TEST_CASE("TidySubsplitDAG: slicing") {
   above.setIdentity();
   auto dag = TidySubsplitDAG(above);
 
-  dag.JoinBelow(1, 0, 2);
-  dag.JoinBelow(3, 1, 4);
+  // The tree ((0,1)3,2)4:
+  dag.JoinBelow(3, 0, 1);
+  dag.JoinBelow(4, 2, 3);
 
-  dag.PrintBelowMatrix();
-  // CHECK_EQ(GenericToString(dag.AboveNode(1)), "[0, 1, 0]\n");
-  // CHECK_EQ(GenericToString(dag.BelowNode(1)), "[0, 1, 1]\n");
+  CHECK_EQ(GenericToString(dag.AboveNode(0)), "[1, 0, 0, 1, 1]\n");
+  CHECK_EQ(GenericToString(dag.AboveNode(1)), "[0, 1, 0, 1, 1]\n");
+  CHECK_EQ(GenericToString(dag.AboveNode(2)), "[0, 0, 1, 0, 1]\n");
+  CHECK_EQ(GenericToString(dag.AboveNode(3)), "[0, 0, 0, 1, 1]\n");
+  CHECK_EQ(GenericToString(dag.AboveNode(4)), "[0, 0, 0, 0, 1]\n");
 }
 #endif  // DOCTEST_LIBRARY_INCLUDED
 

--- a/src/tidy_subsplit_dag.hpp
+++ b/src/tidy_subsplit_dag.hpp
@@ -13,8 +13,8 @@ class TidySubsplitDAG : public SubsplitDAG {
   TidySubsplitDAG();
   explicit TidySubsplitDAG(const RootedTreeCollection &tree_collection);
 
-  EigenColArrayXbRef AboveNode(size_t node_idx);
-  EigenRowArrayXbRef BelowNode(size_t node_idx);
+  EigenArrayXbRef AboveNode(size_t node_idx);
+  EigenArrayXbRef BelowNode(size_t node_idx);
 
  private:
   // above_.(i,j) is true if i is above j, otherwise it's false.

--- a/src/tidy_subsplit_dag.hpp
+++ b/src/tidy_subsplit_dag.hpp
@@ -46,6 +46,8 @@ class TidySubsplitDAG : public SubsplitDAG {
   // Update during #288
   static TidySubsplitDAG MotivatingExample();
 
+  std::string RecordTraversal();
+
   // Apply a TidySubsplitDAGTraversalAction via a depth first traversal. Do not visit
   // leaf nodes. Applied to a given node, we:
   // * Apply BeforeNode
@@ -86,9 +88,9 @@ class TidySubsplitDAG : public SubsplitDAG {
       // We are in updating mode.
       for (const size_t child_id : node->GetLeafward(rotated)) {
         if (!GetDagNode(child_id)->IsLeaf()) {
-          DepthFirstWithActionForNodeClade(action, node_id, false, visited_nodes);
-          DepthFirstWithActionForNodeClade(action, node_id, true, visited_nodes);
-          action.AfterNode(node_id);
+          DepthFirstWithActionForNodeClade(action, child_id, false, visited_nodes);
+          DepthFirstWithActionForNodeClade(action, child_id, true, visited_nodes);
+          action.AfterNode(child_id);
         }
         action.UpdateEdge(node_id, child_id, rotated);
         DirtyVector(rotated)[node_id] = false;
@@ -177,6 +179,8 @@ TEST_CASE("TidySubsplitDAG: slicing") {
            "[0, 0, 0, 0, 1, 0, 1, 0, 0]\n");
   CHECK_EQ(GenericToString(motivating_dag.DirtyVector(false)),
            "[0, 0, 0, 0, 1, 1, 0, 1, 1]\n");
+
+  std::cout << motivating_dag.RecordTraversal();
 }
 #endif  // DOCTEST_LIBRARY_INCLUDED
 

--- a/src/tidy_subsplit_dag.hpp
+++ b/src/tidy_subsplit_dag.hpp
@@ -15,8 +15,6 @@ class TidySubsplitDAG : public SubsplitDAG {
  public:
   TidySubsplitDAG();
   explicit TidySubsplitDAG(const RootedTreeCollection &tree_collection);
-  // This constructor is really just meant for testing.
-  explicit TidySubsplitDAG(size_t node_count);
 
   // What nodes are above or below the specified node? We consider a node to be both
   // above and below itself (this just happens to be handy for the implementation).
@@ -165,6 +163,9 @@ class TidySubsplitDAG : public SubsplitDAG {
   // invalidates the p-hat PLV coming up into it.
   EigenArrayXb dirty_sorted_;
 
+  // This constructor is really just meant for testing.
+  explicit TidySubsplitDAG(size_t node_count);
+
   TidySubsplitDAG(size_t taxon_count, const Node::TopologyCounter &topology_counter);
 
   // Set the below matrix up to have all of the nodes below src_id below the
@@ -175,14 +176,7 @@ class TidySubsplitDAG : public SubsplitDAG {
 
 #ifdef DOCTEST_LIBRARY_INCLUDED
 TEST_CASE("TidySubsplitDAG: slicing") {
-  auto manual_dag = ManualTrivialExample();
-
-  // The tree ((0,1)3,2)4:
-  // https://github.com/phylovi/libsbn/issues/307#issuecomment-766137769
-  manual_dag.SetBelow(3, true, 0);
-  manual_dag.SetBelow(3, false, 1);
-  manual_dag.SetBelow(4, true, 2);
-  manual_dag.SetBelow(4, false, 3);
+  auto manual_dag = TidySubsplitDAG::ManualTrivialExample();
 
   CHECK_EQ(GenericToString(manual_dag.AboveNode(0)), "[1, 0, 0, 1, 1]\n");
   CHECK_EQ(GenericToString(manual_dag.AboveNode(1)), "[0, 1, 0, 1, 1]\n");

--- a/src/tidy_subsplit_dag.hpp
+++ b/src/tidy_subsplit_dag.hpp
@@ -208,7 +208,7 @@ TEST_CASE("TidySubsplitDAG: slicing") {
            "[0, 0, 0, 0, 0, 1, 0, 1, 1]\n");
 
   motivating_dag.SetClean();
-  std::cout << motivating_dag.RecordTraversal();
+  // #310 Add test for Tidy traversal.
 }
 #endif  // DOCTEST_LIBRARY_INCLUDED
 

--- a/src/tidy_subsplit_dag.hpp
+++ b/src/tidy_subsplit_dag.hpp
@@ -34,7 +34,7 @@ class TidySubsplitDAG : public SubsplitDAG {
 
   EigenArrayXbRef DirtyVector(bool rotated);
   bool IsDirtyBelow(size_t node_idx, bool rotated);
-  void SetDirtyAbove(size_t node_idx);
+  void SetDirtyStrictlyAbove(size_t node_idx);
   void SetClean();
 
   std::string AboveMatricesAsString();
@@ -123,7 +123,7 @@ class TidySubsplitDAG : public SubsplitDAG {
           }
         }
         action.ModifyEdge(node_id, child_id, rotated);
-        SetDirtyAbove(node_id);
+        SetDirtyStrictlyAbove(node_id);
         // We assume that ModifyEdge leaves (node_id, rotated) in a clean state.
         DirtyVector(rotated)[node_id] = false;
       }
@@ -184,11 +184,11 @@ TEST_CASE("TidySubsplitDAG: slicing") {
   CHECK_EQ(GenericToString(motivating_dag.BelowNode(true, 7)),
            "[1, 0, 0, 0, 0, 0, 0, 1, 0]\n");
 
-  motivating_dag.SetDirtyAbove(4);
+  motivating_dag.SetDirtyStrictlyAbove(4);
   CHECK_EQ(GenericToString(motivating_dag.DirtyVector(true)),
-           "[0, 0, 0, 0, 1, 0, 1, 0, 0]\n");
+           "[0, 0, 0, 0, 0, 0, 1, 0, 0]\n");
   CHECK_EQ(GenericToString(motivating_dag.DirtyVector(false)),
-           "[0, 0, 0, 0, 1, 1, 0, 1, 1]\n");
+           "[0, 0, 0, 0, 0, 1, 0, 1, 1]\n");
 
   motivating_dag.SetClean();
   std::cout << motivating_dag.RecordTraversal();

--- a/src/tidy_subsplit_dag.hpp
+++ b/src/tidy_subsplit_dag.hpp
@@ -75,6 +75,7 @@ class TidySubsplitDAG : public SubsplitDAG {
                                        size_t node_id,
                                        std::unordered_set<size_t> &visited_nodes) {
     action.BeforeNode(node_id);
+    // #288 Here we are doing true and then false (left and then right).
     DepthFirstWithTidyActionForNodeClade(action, node_id, true, visited_nodes);
     DepthFirstWithTidyActionForNodeClade(action, node_id, false, visited_nodes);
     action.AfterNode(node_id);
@@ -102,6 +103,7 @@ class TidySubsplitDAG : public SubsplitDAG {
       const auto node = GetDagNode(node_id);
       for (const size_t child_id : node->GetLeafward(rotated)) {
         if (!GetDagNode(child_id)->IsLeaf()) {
+          // #288 Here we are doing true and then false (left and then right).
           DepthFirstWithTidyActionForNodeClade(action, child_id, true, visited_nodes);
           DepthFirstWithTidyActionForNodeClade(action, child_id, false, visited_nodes);
           action.AfterNode(child_id);

--- a/src/tidy_subsplit_dag.hpp
+++ b/src/tidy_subsplit_dag.hpp
@@ -11,21 +11,26 @@
 class TidySubsplitDAG : public SubsplitDAG {
  public:
   TidySubsplitDAG();
+  explicit TidySubsplitDAG(const RootedTreeCollection &tree_collection);
   // This constructor is really just meant for testing.
   explicit TidySubsplitDAG(size_t node_count);
-  explicit TidySubsplitDAG(const RootedTreeCollection &tree_collection);
 
   // What nodes are above or below the specified node? We consider a node to be both
   // above and below itself (this just happens to be handy for the implementation).
-  EigenArrayXbRef BelowNode(size_t node_idx);
+  EigenArrayXb BelowNode(size_t node_idx);
+  EigenArrayXbRef BelowNode(bool rotated, size_t node_idx);
   EigenArrayXb AboveNode(size_t node_idx);
-  void JoinBelow(size_t dst, size_t src1, size_t src2);
+  EigenArrayXb AboveNode(bool rotated, size_t node_idx);
 
-  void PrintBelowMatrix();
+  // Set the below matrix up to have the node at src_idx below the subsplit-clade
+  // described by (dst_rotated, dst_idx).
+  void SetBelow(size_t dst_idx, bool dst_rotated, size_t src_idx);
 
  private:
-  // above_.(i,j) is true if i is above j, otherwise it's false.
-  EigenMatrixXb above_;
+  // above_rotated_.(i,j) is true iff i,true is above j.
+  EigenMatrixXb above_rotated_;
+  // above_sorted.(i,j) is true iff i,false is above j.
+  EigenMatrixXb above_sorted_;
 };
 
 #ifdef DOCTEST_LIBRARY_INCLUDED
@@ -33,8 +38,10 @@ TEST_CASE("TidySubsplitDAG: slicing") {
   auto dag = TidySubsplitDAG(5);
 
   // The tree ((0,1)3,2)4:
-  dag.JoinBelow(3, 0, 1);
-  dag.JoinBelow(4, 2, 3);
+  dag.SetBelow(3, true, 0);
+  dag.SetBelow(3, false, 1);
+  dag.SetBelow(4, true, 3);
+  dag.SetBelow(4, false, 2);
 
   CHECK_EQ(GenericToString(dag.AboveNode(0)), "[1, 0, 0, 1, 1]\n");
   CHECK_EQ(GenericToString(dag.AboveNode(1)), "[0, 1, 0, 1, 1]\n");

--- a/src/tree_collection.hpp
+++ b/src/tree_collection.hpp
@@ -11,7 +11,9 @@ using TreeCollection = GenericTreeCollection<Tree>;
 
 #ifdef DOCTEST_LIBRARY_INCLUDED
 TEST_CASE("TreeCollection") {
-  TreeCollection collection(Tree::ExampleTrees());
+  auto first_four_example_trees = Tree::ExampleTrees();
+  first_four_example_trees.resize(4);
+  TreeCollection collection(first_four_example_trees);
   auto counter = collection.TopologyCounter();
   std::unordered_map<std::string, uint32_t> counted;
   for (const auto &iter : counter) {


### PR DESCRIPTION
## Description

* dirty status is implemented as a binary vector indexed by DAG node
* we have a binary matrix indicating what DAG nodes are below which other ones
* before traversing down into a subsplit-clade for optimization, we check to see if the other clade is clean
    * if not, we recur down it, looking for dirty nodes, with UpdateEdge and all of the Before and After steps until all edges are clean
* once things are clean, recur down into subsplit-clade for optimization as currently done, dirtying nodes above us

Also:

* can export subsplit DAG to DOT format
* additional Bitset functionality for related things

Closes #307 

## Tests

Good test coverage for the above/below and dirty setup. More traversal tests are deferred until #321. 

## Checklist:

* [ ] The code uses informative and accurate variable and function names
* [x] The functionality is factored out into functions and methods with logical interfaces
* [ ] Comments are up to date, document intent, and there are no commented-out code blocks
* [x] Commenting and/or documentation is sufficient for others to be able to understand intent and implementation
* [x] Entities are named according to our conventions
* [x] `const` used where appropriate
* [x] The code uses modern C++ conventions, including range-for, `auto`, and structured bindings
* [x] `make format` has been run
* [x] TODOs have been eliminated from the code
* [x] The corresponding issue number (e.g. `#278`) has been searched for in the code to find relevant notes
