### PR TITLE
Replaced UnrootedPhyloGradient and RootedPhyloGradient classes with PhyloGradient

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -75,19 +75,18 @@ std::vector<double> Engine::UnrootedLogLikelihoods(
       phylo_model_params, rescaling);
 }
 
-std::vector<UnrootedPhyloGradient> Engine::Gradients(
+std::vector<PhyloGradient> Engine::Gradients(
     const UnrootedTreeCollection &tree_collection,
     const EigenMatrixXdRef phylo_model_params, const bool rescaling) const {
-  return FatBeagleParallelize<UnrootedPhyloGradient, UnrootedTree,
-                              UnrootedTreeCollection>(FatBeagle::StaticUnrootedGradient,
-                                                      fat_beagles_, tree_collection,
-                                                      phylo_model_params, rescaling);
+  return FatBeagleParallelize<PhyloGradient, UnrootedTree, UnrootedTreeCollection>(
+      FatBeagle::StaticUnrootedGradient, fat_beagles_, tree_collection,
+      phylo_model_params, rescaling);
 }
 
-std::vector<RootedPhyloGradient> Engine::Gradients(
+std::vector<PhyloGradient> Engine::Gradients(
     const RootedTreeCollection &tree_collection,
     const EigenMatrixXdRef phylo_model_params, const bool rescaling) const {
-  return FatBeagleParallelize<RootedPhyloGradient, RootedTree, RootedTreeCollection>(
+  return FatBeagleParallelize<PhyloGradient, RootedTree, RootedTreeCollection>(
       FatBeagle::StaticRootedGradient, fat_beagles_, tree_collection,
       phylo_model_params, rescaling);
 }

--- a/src/engine.hpp
+++ b/src/engine.hpp
@@ -39,12 +39,12 @@ class Engine {
   std::vector<double> UnrootedLogLikelihoods(
       const RootedTreeCollection &tree_collection,
       const EigenMatrixXdRef phylo_model_params, const bool rescaling) const;
-  std::vector<UnrootedPhyloGradient> Gradients(
-      const UnrootedTreeCollection &tree_collection,
-      const EigenMatrixXdRef phylo_model_params, const bool rescaling) const;
-  std::vector<RootedPhyloGradient> Gradients(
-      const RootedTreeCollection &tree_collection,
-      const EigenMatrixXdRef phylo_model_params, const bool rescaling) const;
+  std::vector<PhyloGradient> Gradients(const UnrootedTreeCollection &tree_collection,
+                                       const EigenMatrixXdRef phylo_model_params,
+                                       const bool rescaling) const;
+  std::vector<PhyloGradient> Gradients(const RootedTreeCollection &tree_collection,
+                                       const EigenMatrixXdRef phylo_model_params,
+                                       const bool rescaling) const;
 
  private:
   SitePattern site_pattern_;

--- a/src/fat_beagle.hpp
+++ b/src/fat_beagle.hpp
@@ -46,8 +46,8 @@ class FatBeagle {
   double LogLikelihood(const RootedTree &tree) const;
   // Compute first derivative of the log likelihood with respect to each branch
   // length, as a vector of first derivatives indexed by node id.
-  UnrootedPhyloGradient Gradient(const UnrootedTree &tree) const;
-  RootedPhyloGradient Gradient(const RootedTree &tree) const;
+  PhyloGradient Gradient(const UnrootedTree &tree) const;
+  PhyloGradient Gradient(const RootedTree &tree) const;
 
   // We can pass these static methods to FatBeagleParallelize.
   static double StaticUnrootedLogLikelihood(FatBeagle *fat_beagle,
@@ -58,10 +58,10 @@ class FatBeagle {
                                                     const RootedTree &in_tree);
   static double StaticRootedLogLikelihood(FatBeagle *fat_beagle,
                                           const RootedTree &in_tree);
-  static UnrootedPhyloGradient StaticUnrootedGradient(FatBeagle *fat_beagle,
-                                                      const UnrootedTree &in_tree);
-  static RootedPhyloGradient StaticRootedGradient(FatBeagle *fat_beagle,
-                                                  const RootedTree &in_tree);
+  static PhyloGradient StaticUnrootedGradient(FatBeagle *fat_beagle,
+                                              const UnrootedTree &in_tree);
+  static PhyloGradient StaticRootedGradient(FatBeagle *fat_beagle,
+                                            const RootedTree &in_tree);
 
  private:
   using BeagleInstance = int;

--- a/src/pylibsbn.cpp
+++ b/src/pylibsbn.cpp
@@ -85,17 +85,6 @@ PYBIND11_MODULE(libsbn, m) {
       .def_readwrite("trees", &RootedTreeCollection::trees_);
 
   // CLASS
-  // RootedPhyloGradient
-  py::class_<RootedPhyloGradient>(m, "RootedPhyloGradient",
-                                  R"raw(A rooted tree phylogenetic gradient.)raw")
-      .def_readonly("log_likelihood", &RootedPhyloGradient::log_likelihood_)
-      .def_readonly("site_model", &RootedPhyloGradient::site_model_)
-      .def_readonly("substitution_model", &RootedPhyloGradient::substitution_model_)
-      .def_readonly("branch_lengths", &RootedPhyloGradient::branch_lengths_)
-      .def_readonly("clock_model", &RootedPhyloGradient::clock_model_)
-      .def_readonly("ratios_root_height", &RootedPhyloGradient::ratios_root_height_);
-
-  // CLASS
   // UnrootedTree
   py::class_<UnrootedTree>(m, "UnrootedTree", "An unrooted tree with branch lengths.",
                            py::buffer_protocol())
@@ -126,13 +115,10 @@ PYBIND11_MODULE(libsbn, m) {
            "Get the current set of trees as a big Newick string.")
       .def_readwrite("trees", &UnrootedTreeCollection::trees_);
 
-  // UnrootedPhyloGradient
-  py::class_<UnrootedPhyloGradient>(m, "UnrootedPhyloGradient",
-                                    R"raw(An unrooted tree phylogenetic gradient.)raw")
-      .def_readonly("log_likelihood", &UnrootedPhyloGradient::log_likelihood_)
-      .def_readonly("site_model", &UnrootedPhyloGradient::site_model_)
-      .def_readonly("substitution_model", &UnrootedPhyloGradient::substitution_model_)
-      .def_readonly("branch_lengths", &UnrootedPhyloGradient::branch_lengths_);
+  // PhyloGradient
+  py::class_<PhyloGradient>(m, "PhyloGradient", R"raw(A phylogenetic gradient.)raw")
+      .def_readonly("log_likelihood", &PhyloGradient::log_likelihood_)
+      .def_readonly("gradient", &PhyloGradient::gradient_);
 
   // CLASS
   // PSPIndexer

--- a/src/rooted_sbn_instance.cpp
+++ b/src/rooted_sbn_instance.cpp
@@ -41,7 +41,7 @@ std::vector<double> RootedSBNInstance::UnrootedLogLikelihoods() {
                                              rescaling_);
 }
 
-std::vector<RootedPhyloGradient> RootedSBNInstance::PhyloGradients() {
+std::vector<PhyloGradient> RootedSBNInstance::PhyloGradients() {
   return GetEngine()->Gradients(tree_collection_, phylo_model_params_, rescaling_);
 }
 

--- a/src/rooted_sbn_instance.hpp
+++ b/src/rooted_sbn_instance.hpp
@@ -37,7 +37,7 @@ class RootedSBNInstance : public PreRootedSBNInstance {
   std::vector<double> LogLikelihoods();
   std::vector<double> UnrootedLogLikelihoods();
   // For each loaded tree, return the phylogenetic gradient.
-  std::vector<RootedPhyloGradient> PhyloGradients();
+  std::vector<PhyloGradient> PhyloGradients();
 
   // ** I/O
 
@@ -274,7 +274,9 @@ TEST_CASE("RootedSBNInstance: gradients") {
       48.871694, 3.488516,   82.969065, 9.009334,  8.032474,  3.981016,   6.543650,
       53.702423, 37.835952,  2.840831,  7.517186,  19.936861};
   for (size_t i = 0; i < physher_gradients.size(); i++) {
-    CHECK_LT(fabs(gradients[0].ratios_root_height_[i] - physher_gradients[i]), 0.0001);
+    CHECK_LT(
+        fabs(gradients[0].gradient_["ratios_root_height"][i] - physher_gradients[i]),
+        0.0001);
   }
   CHECK_LT(fabs(gradients[0].log_likelihood_ - physher_ll), 0.0001);
 }
@@ -292,7 +294,8 @@ TEST_CASE("RootedSBNInstance: clock gradients") {
   // Gradient with a strict clock.
   auto gradients_strict = inst.PhyloGradients();
   std::vector<double> gradients_strict_approx = DerivativeStrictClock(inst);
-  CHECK_LT(fabs(gradients_strict[0].clock_model_[0] - gradients_strict_approx[0]),
+  CHECK_LT(fabs(gradients_strict[0].gradient_["clock_model"][0] -
+                gradients_strict_approx[0]),
            0.001);
   CHECK_LT(fabs(gradients_strict[0].log_likelihood_ - physher_ll), 0.001);
 
@@ -308,9 +311,9 @@ TEST_CASE("RootedSBNInstance: clock gradients") {
   auto gradients_relaxed_approx = DerivativeRelaxedClock(inst);
 
   for (size_t j = 0; j < gradients_relaxed_approx.size(); j++) {
-    CHECK_LT(
-        fabs(gradients_relaxed[0].clock_model_[j] - gradients_relaxed_approx[j][0]),
-        0.001);
+    CHECK_LT(fabs(gradients_relaxed[0].gradient_["clock_model"][j] -
+                  gradients_relaxed_approx[j][0]),
+             0.001);
   }
 }
 
@@ -331,7 +334,7 @@ TEST_CASE("RootedSBNInstance: Weibull gradients") {
   // Gradient wrt Weibull site model.
   auto gradients = inst.PhyloGradients();
   double physher_gradient = -5.231329;
-  CHECK_LT(fabs(gradients[0].site_model_[0] - physher_gradient), 0.001);
+  CHECK_LT(fabs(gradients[0].gradient_["site_model"][0] - physher_gradient), 0.001);
   CHECK_LT(fabs(gradients[0].log_likelihood_ - physher_ll), 0.001);
 }
 

--- a/src/tree_gradient.hpp
+++ b/src/tree_gradient.hpp
@@ -4,48 +4,18 @@
 #ifndef SRC_TREE_GRADIENT_HPP_
 #define SRC_TREE_GRADIENT_HPP_
 
+#include <map>
 #include <vector>
+
+using GradientMap = std::map<std::string, std::vector<double>>;
 
 struct PhyloGradient {
   PhyloGradient() = default;
-  PhyloGradient(double log_likelihood, std::vector<double> site_model_gradient,
-                std::vector<double> substitution_model_gradient)
-      : log_likelihood_(log_likelihood),
-        site_model_(site_model_gradient),
-        substitution_model_(substitution_model_gradient){};
+  PhyloGradient(double log_likelihood, GradientMap& gradient)
+      : log_likelihood_(log_likelihood), gradient_(gradient){};
 
   double log_likelihood_;
-  std::vector<double> site_model_;
-  std::vector<double> substitution_model_;
-};
-
-struct UnrootedPhyloGradient : PhyloGradient {
-  UnrootedPhyloGradient() = default;
-  UnrootedPhyloGradient(double log_likelihood,
-                        std::vector<double> branch_length_gradient,
-                        std::vector<double> site_model_gradient,
-                        std::vector<double> substitution_model_gradient)
-      : PhyloGradient(log_likelihood, site_model_gradient, substitution_model_gradient),
-        branch_lengths_(branch_length_gradient){};
-
-  std::vector<double> branch_lengths_;
-};
-
-struct RootedPhyloGradient : PhyloGradient {
-  RootedPhyloGradient() = default;
-  RootedPhyloGradient(double log_likelihood, std::vector<double> branch_length_gradient,
-                      std::vector<double> ratios_root_height_gradient,
-                      std::vector<double> clock_model_gradient,
-                      std::vector<double> site_model_gradient,
-                      std::vector<double> substitution_model_gradient)
-      : PhyloGradient(log_likelihood, site_model_gradient, substitution_model_gradient),
-        branch_lengths_(branch_length_gradient),
-        clock_model_(clock_model_gradient),
-        ratios_root_height_(ratios_root_height_gradient){};
-
-  std::vector<double> branch_lengths_;
-  std::vector<double> clock_model_;
-  std::vector<double> ratios_root_height_;
+  GradientMap gradient_;
 };
 
 #endif  // SRC_TREE_GRADIENT_HPP_

--- a/src/unrooted_sbn_instance.cpp
+++ b/src/unrooted_sbn_instance.cpp
@@ -95,7 +95,7 @@ std::vector<double> UnrootedSBNInstance::LogLikelihoods() {
   return GetEngine()->LogLikelihoods(tree_collection_, phylo_model_params_, rescaling_);
 }
 
-std::vector<UnrootedPhyloGradient> UnrootedSBNInstance::PhyloGradients() {
+std::vector<PhyloGradient> UnrootedSBNInstance::PhyloGradients() {
   return GetEngine()->Gradients(tree_collection_, phylo_model_params_, rescaling_);
 }
 

--- a/src/unrooted_sbn_instance.hpp
+++ b/src/unrooted_sbn_instance.hpp
@@ -56,7 +56,7 @@ class UnrootedSBNInstance : public PreUnrootedSBNInstance {
   std::vector<double> LogLikelihoods();
 
   // For each loaded tree, return the phylogenetic gradient.
-  std::vector<UnrootedPhyloGradient> PhyloGradients();
+  std::vector<PhyloGradient> PhyloGradients();
   // Topology gradient for unrooted trees.
   // Assumption: This function is called from Python side
   // after the trees (both the topology and the branch lengths) are sampled.
@@ -238,7 +238,8 @@ TEST_CASE("UnrootedSBNInstance: likelihood and gradient") {
       }
       // Test the gradients for the last tree.
       auto last = gradients.back();
-      std::sort(last.branch_lengths_.begin(), last.branch_lengths_.end());
+      std::sort(last.gradient_["branch_lengths"].begin(),
+                last.gradient_["branch_lengths"].end());
       // Zeros are for the root and one of the descendants of the root.
       std::vector<double> physher_gradients = {
           -904.18956, -607.70500, -562.36274, -553.63315, -542.26058, -539.64210,
@@ -250,8 +251,9 @@ TEST_CASE("UnrootedSBNInstance: likelihood and gradient") {
           255.52967,  259.90378,  394.00504,  394.96619,  396.98933,  429.83873,
           450.71566,  462.75827,  471.57364,  472.83161,  514.59289,  650.72575,
           888.87834,  913.96566,  927.14730,  959.10746,  2296.55028};
-      for (size_t i = 0; i < last.branch_lengths_.size(); i++) {
-        CHECK_LT(fabs(last.branch_lengths_[i] - physher_gradients[i]), 0.0001);
+      for (size_t i = 0; i < last.gradient_["branch_lengths"].size(); i++) {
+        CHECK_LT(fabs(last.gradient_["branch_lengths"][i] - physher_gradients[i]),
+                 0.0001);
       }
 
       // Test rescaling
@@ -270,11 +272,10 @@ TEST_CASE("UnrootedSBNInstance: likelihood and gradient") {
       }
       // Gradients
       auto last_rescaling = gradients_rescaling.back();
-      std::sort(last_rescaling.branch_lengths_.begin(),
-                last_rescaling.branch_lengths_.end());
-      for (size_t i = 0; i < last_rescaling.branch_lengths_.size(); i++) {
-        CHECK_LT(fabs(last_rescaling.branch_lengths_[i] - physher_gradients[i]),
-                 0.0001);
+      auto branch_lengths_gradient = last_rescaling.gradient_["branch_lengths"];
+      std::sort(branch_lengths_gradient.begin(), branch_lengths_gradient.end());
+      for (size_t i = 0; i < branch_lengths_gradient.size(); i++) {
+        CHECK_LT(fabs(branch_lengths_gradient[i] - physher_gradients[i]), 0.0001);
       }
     }
   }
@@ -310,7 +311,8 @@ TEST_CASE("UnrootedSBNInstance: likelihood and gradient with Weibull") {
 
       auto gradients = inst.PhyloGradients();
       for (size_t i = 0; i < gradients.size(); i++) {
-        CHECK_LT(fabs(gradients[i].branch_lengths_[0] - physher_gradients_bl0[i]),
+        CHECK_LT(fabs(gradients[i].gradient_["branch_lengths"][0] -
+                      physher_gradients_bl0[i]),
                  0.00011);
       }
 
@@ -324,9 +326,9 @@ TEST_CASE("UnrootedSBNInstance: likelihood and gradient with Weibull") {
 
       auto gradients_rescaling = inst.PhyloGradients();
       for (size_t i = 0; i < gradients.size(); i++) {
-        CHECK_LT(
-            fabs(gradients_rescaling[i].branch_lengths_[0] - physher_gradients_bl0[i]),
-            0.00011);
+        CHECK_LT(fabs(gradients_rescaling[i].gradient_["branch_lengths"][0] -
+                      physher_gradients_bl0[i]),
+                 0.00011);
       }
     }
   }


### PR DESCRIPTION
## Description

PhyloGradient is an object containing a log_likelihood variable and a gradient variable. The gradient variable is a map containing derivatives for each sub-model.
For now the keys in the map are the variable names in the old UnrootedPhyloGradient and RootedPhyloGradient objects. Eventually the keys will be the unique identifiers of the parameters of the model.
The goal is to be add flexibility in order to add more complex models models (e.g. SRD06, phylogeography)