### PR TITLE
Gradient of substitution model using finite differences

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -165,6 +165,7 @@ sources = [
     "_build/scanner.cpp",
     "_build/site_model.cpp",
     "_build/site_pattern.cpp",
+    "_build/stick_breaking_transform.cpp",
     "_build/subsplit_dag.cpp",
     "_build/subsplit_dag_node.cpp",
     "_build/substitution_model.cpp",

--- a/src/fat_beagle.hpp
+++ b/src/fat_beagle.hpp
@@ -63,6 +63,11 @@ class FatBeagle {
   static PhyloGradient StaticRootedGradient(FatBeagle *fat_beagle,
                                             const RootedTree &in_tree);
 
+  template <typename TTree>
+  std::vector<double> SubstitutionModelGradient(
+      std::function<double(FatBeagle *, const TTree &)> f, FatBeagle *fat_beagle,
+      const TTree &tree) const;
+
  private:
   using BeagleInstance = int;
   using BeagleOperationVector = std::vector<BeagleOperation>;

--- a/src/fat_beagle.hpp
+++ b/src/fat_beagle.hpp
@@ -66,8 +66,8 @@ class FatBeagle {
   template <typename TTree>
   std::vector<double> SubstitutionModelGradientFiniteDifference(
       std::function<double(FatBeagle *, const TTree &)> f, FatBeagle *fat_beagle,
-      const TTree &tree, SubstitutionModel *subst_model, EigenVectorXdRef &parameters,
-      double delta = 1.e-8) const;
+      const TTree &tree, SubstitutionModel *subst_model,
+      const std::string &parameter_key, EigenVectorXd param_vector, double delta) const;
 
   template <typename TTree>
   std::vector<double> SubstitutionModelGradient(

--- a/src/fat_beagle.hpp
+++ b/src/fat_beagle.hpp
@@ -64,6 +64,12 @@ class FatBeagle {
                                             const RootedTree &in_tree);
 
   template <typename TTree>
+  std::vector<double> SubstitutionModelGradientFiniteDifference(
+      std::function<double(FatBeagle *, const TTree &)> f, FatBeagle *fat_beagle,
+      const TTree &tree, SubstitutionModel *subst_model, EigenVectorXdRef &parameters,
+      double delta = 1.e-8) const;
+
+  template <typename TTree>
   std::vector<double> SubstitutionModelGradient(
       std::function<double(FatBeagle *, const TTree &)> f, FatBeagle *fat_beagle,
       const TTree &tree) const;
@@ -84,7 +90,7 @@ class FatBeagle {
   void SetTipStates(const SitePattern &site_pattern);
   void SetTipPartials(const SitePattern &site_pattern);
   void UpdateSiteModelInBeagle();
-  void UpdateSubstitutionModelInBeagle();
+  void UpdateSubstitutionModelInBeagle() const;
   void UpdatePhyloModelInBeagle();
 
   double LogLikelihoodInternals(const Node::NodePtr topology,

--- a/src/rooted_sbn_instance.hpp
+++ b/src/rooted_sbn_instance.hpp
@@ -325,23 +325,24 @@ TEST_CASE("RootedSBNInstance: GTR gradients") {
     tree.rates_.assign(tree.rates_.size(), 0.001);
   }
   auto param_block_map = inst.GetPhyloModelParamBlockMap();
-  auto frequencies = param_block_map.at(GTRModel::frequencies_key_);
-  auto rates = param_block_map.at(GTRModel::rates_key_);
+  EigenVectorXdRef frequencies = param_block_map.at(GTRModel::frequencies_key_);
+  EigenVectorXdRef rates = param_block_map.at(GTRModel::rates_key_);
   frequencies << 0.1, 0.2, 0.3, 0.4;
   rates << 0.05, 0.1, 0.15, 0.20, 0.25, 0.25;
 
   auto likelihood = inst.LogLikelihoods();
-  double phylotorch_ll = -5221.437446315317;
-  CHECK_LT(fabs(likelihood[0] - phylotorch_ll), 0.0001);
+  double phylotorch_ll = -5221.438941335706;
+  CHECK_LT(fabs(likelihood[0] - phylotorch_ll), 0.001);
 
-  // Gradient wrt Weibull site model.
   auto gradients = inst.PhyloGradients();
-  double physher_gradient = -5.231329;
-  for (double derivative : gradients[0].gradient_["substitution_model"]) {
-    std::cout << "==== derivative" << derivative << std::endl;
+  std::vector<double> phylotorch_gradients = {49.06451538, 151.83105912, 26.40235659,
+                                              -8.25135661, 75.29759338,  352.56545247,
+                                              90.07046995, 30.12301652};
+  for (size_t i = 0; i < phylotorch_gradients.size(); i++) {
+    CHECK_LT(
+        fabs(gradients[0].gradient_["substitution_model"][i] - phylotorch_gradients[i]),
+        0.001);
   }
-  CHECK_LT(fabs(gradients[0].gradient_["substitution_model"][0] - physher_gradient),
-           0.001);
   CHECK_LT(fabs(gradients[0].log_likelihood_ - phylotorch_ll), 0.001);
 }
 

--- a/src/stick_breaking_transform.cpp
+++ b/src/stick_breaking_transform.cpp
@@ -1,5 +1,9 @@
 // Copyright 2019-2021 libsbn project contributors.
 // libsbn is free software under the GPLv3; see LICENSE file for details.
+//
+// This code closely follows
+// https://mc-stan.org/docs/2_26/reference-manual/simplex-transform-section.html
+// and so we follow their notation.
 
 #include "stick_breaking_transform.hpp"
 
@@ -17,13 +21,12 @@ EigenVectorXd StickBreakingTransform::operator()(EigenVectorXd const& y) const {
   size_t K = y.size() + 1;
   EigenVectorXd x(K);
   double stick = 1.0;
-  size_t k = 0;
-  for (; k < K - 1; k++) {
+  for (size_t k = 0; k < K - 1; k++) {
     double z = inverse_logit(y[k] - std::log(K - k - 1));
     x[k] = stick * z;
     stick -= x[k];
   }
-  x[k] = stick;
+  x[K - 1] = stick;
   return x;
 }
 

--- a/src/stick_breaking_transform.cpp
+++ b/src/stick_breaking_transform.cpp
@@ -9,8 +9,8 @@ inline double logit(const double x) { return std::log(x / (1.0 - x)); }
 
 inline double log1p_exp(double a) {
   // prevents underflow
-  if (a > 0.0) return a + log1p(exp(-a));
-  return log1p(exp(a));
+  if (a > 0.0) return a + std::log1p(exp(-a));
+  return std::log1p(exp(a));
 }
 
 EigenVectorXd StickBreakingTransform::operator()(EigenVectorXd const& y) const {

--- a/src/stick_breaking_transform.cpp
+++ b/src/stick_breaking_transform.cpp
@@ -1,0 +1,55 @@
+// Copyright 2019-2021 libsbn project contributors.
+// libsbn is free software under the GPLv3; see LICENSE file for details.
+
+#include "stick_breaking_transform.hpp"
+
+inline double inverse_logit(const double y) { return 1.0 / (1 + std::exp(-y)); }
+
+inline double logit(const double x) { return std::log(x / (1.0 - x)); }
+
+inline double log1p_exp(double a) {
+  // prevents underflow
+  if (a > 0.0) return a + log1p(exp(-a));
+  return log1p(exp(a));
+}
+
+EigenVectorXd StickBreakingTransform::operator()(EigenVectorXd const& y) const {
+  size_t K = y.size() + 1;
+  EigenVectorXd x(K);
+  double stick = 1.0;
+  size_t k = 0;
+  for (; k < K - 1; k++) {
+    double z = inverse_logit(y[k] - std::log(K - k - 1));
+    x[k] = stick * z;
+    stick -= x[k];
+  }
+  x[k] = stick;
+  return x;
+}
+
+EigenVectorXd StickBreakingTransform::inverse(const EigenVectorXd& x) const {
+  size_t K = x.size();
+  double sum = 0;
+  EigenVectorXd y(K - 1);
+  for (size_t k = 0; k < K - 1; k++) {
+    double z = x[k] / (1.0 - sum);
+    y[k] = logit(z) + std::log(K - k - 1);
+    sum += x[k];
+  }
+  return y;
+}
+
+double StickBreakingTransform::log_abs_det_jacobian(const EigenVectorXd& x,
+                                                    const EigenVectorXd& y) const {
+  size_t K = x.size();
+  double log_prob = 0.0;
+  double stick = 1.0;
+  for (size_t k = 0; k < K - 1; k++) {
+    double adj_y_k = y[k] - log(K - k - 1);
+    log_prob += std::log(stick);
+    log_prob -= log1p_exp(-adj_y_k);
+    log_prob -= log1p_exp(adj_y_k);
+    stick -= x[k];
+  }
+  return log_prob;
+}

--- a/src/stick_breaking_transform.hpp
+++ b/src/stick_breaking_transform.hpp
@@ -7,6 +7,9 @@
 #include "eigen_sugar.hpp"
 
 class Transform {
+ public:
+  virtual ~Transform() = default;
+
   virtual EigenVectorXd operator()(EigenVectorXd const& x) const = 0;
 
   virtual EigenVectorXd inverse(EigenVectorXd const& y) const = 0;
@@ -19,6 +22,8 @@ class StickBreakingTransform : public Transform {
   // The stick breaking procedure as defined in Stan
   // https://mc-stan.org/docs/2_26/reference-manual/simplex-transform-section.html
  public:
+  virtual ~StickBreakingTransform() = default;
+
   EigenVectorXd operator()(EigenVectorXd const& x) const;
 
   EigenVectorXd inverse(EigenVectorXd const& y) const;

--- a/src/stick_breaking_transform.hpp
+++ b/src/stick_breaking_transform.hpp
@@ -16,6 +16,8 @@ class Transform {
 };
 
 class StickBreakingTransform : public Transform {
+  // The stick breaking procedure as defined in Stan
+  // https://mc-stan.org/docs/2_26/reference-manual/simplex-transform-section.html
  public:
   EigenVectorXd operator()(EigenVectorXd const& x) const;
 
@@ -30,12 +32,17 @@ TEST_CASE("BreakingStickTransform") {
   EigenVectorXd y(3);
   y << 1., 2., 3.;
   EigenVectorXd x_expected(3);
+  // x_expected =
+  // torch.distributions.StickBreakingTransform()(torch.tensor([1., 2., 3.]))
   x_expected << 0.475367, 0.412879, 0.106454, 0.00530004;
   EigenVectorXd x = a(y);
   CheckVectorXdEquality(x, x_expected, 1.e-5);
   EigenVectorXd yy = a.inverse(x);
   CheckVectorXdEquality(y, yy, 1e-5);
-  CHECK_EQ(a.log_abs_det_jacobian(x, y), -9.108352, 1.e-5);
+  // log_abs_det_jacobian_expected =
+  // torch.distributions.StickBreakingTransform().log_abs_det_jacobian(y,x)
+  double log_abs_det_jacobian_expected = -9.108352;
+  CHECK_EQ(a.log_abs_det_jacobian(x, y), log_abs_det_jacobian_expected, 1.e-5);
 }
 #endif  // DOCTEST_LIBRARY_INCLUDED
 

--- a/src/stick_breaking_transform.hpp
+++ b/src/stick_breaking_transform.hpp
@@ -1,0 +1,42 @@
+// Copyright 2019-2021 libsbn project contributors.
+// libsbn is free software under the GPLv3; see LICENSE file for details.
+
+#ifndef SRC_STICK_BREAKING_TRANSFORM_HPP_
+#define SRC_STICK_BREAKING_TRANSFORM_HPP_
+
+#include "eigen_sugar.hpp"
+
+class Transform {
+  virtual EigenVectorXd operator()(EigenVectorXd const& x) const = 0;
+
+  virtual EigenVectorXd inverse(EigenVectorXd const& y) const = 0;
+
+  virtual double log_abs_det_jacobian(const EigenVectorXd& x,
+                                      const EigenVectorXd& y) const = 0;
+};
+
+class StickBreakingTransform : public Transform {
+ public:
+  EigenVectorXd operator()(EigenVectorXd const& x) const;
+
+  EigenVectorXd inverse(EigenVectorXd const& y) const;
+
+  double log_abs_det_jacobian(const EigenVectorXd& x, const EigenVectorXd& y) const;
+};
+
+#ifdef DOCTEST_LIBRARY_INCLUDED
+TEST_CASE("BreakingStickTransform") {
+  StickBreakingTransform a;
+  EigenVectorXd y(3);
+  y << 1., 2., 3.;
+  EigenVectorXd x_expected(3);
+  x_expected << 0.475367, 0.412879, 0.106454, 0.00530004;
+  EigenVectorXd x = a(y);
+  CheckVectorXdEquality(x, x_expected, 1.e-5);
+  EigenVectorXd yy = a.inverse(x);
+  CheckVectorXdEquality(y, yy, 1e-5);
+  CHECK_EQ(a.log_abs_det_jacobian(x, y), -9.108352, 1.e-5);
+}
+#endif  // DOCTEST_LIBRARY_INCLUDED
+
+#endif  // SRC_STICK_BREAKING_TRANSFORM_HPP_

--- a/src/substitution_model.cpp
+++ b/src/substitution_model.cpp
@@ -19,7 +19,12 @@ void GTRModel::SetParameters(const EigenVectorXdRef param_vector) {
   rates_ = ExtractSegment(param_vector, rates_key_);
   frequencies_ = ExtractSegment(param_vector, frequencies_key_);
   if (fabs(frequencies_.sum() - 1.) >= 0.001) {
+    std::cerr << frequencies_ << std::endl;
     Failwith("GTR frequencies do not sum to 1 +/- 0.001!");
+  }
+  if (fabs(rates_.sum() - 1.) >= 0.001) {
+    std::cerr << rates_ << std::endl;
+    Failwith("GTR rates do not sum to 1 +/- 0.001!");
   }
   Update();
 };

--- a/src/substitution_model.cpp
+++ b/src/substitution_model.cpp
@@ -19,12 +19,19 @@ void GTRModel::SetParameters(const EigenVectorXdRef param_vector) {
   rates_ = ExtractSegment(param_vector, rates_key_);
   frequencies_ = ExtractSegment(param_vector, frequencies_key_);
   if (fabs(frequencies_.sum() - 1.) >= 0.001) {
-    std::cerr << frequencies_ << std::endl;
-    Failwith("GTR frequencies do not sum to 1 +/- 0.001!");
+    std::ostringstream oss;
+    std::copy(frequencies_.begin(), frequencies_.end() - 1,
+              std::ostream_iterator<double>(oss, ","));
+    oss << *frequencies_.end();
+    Failwith("GTR frequencies do not sum to 1 +/- 0.001! frequency vector: (" +
+             oss.str() + ")");
   }
   if (fabs(rates_.sum() - 1.) >= 0.001) {
-    std::cerr << rates_ << std::endl;
-    Failwith("GTR rates do not sum to 1 +/- 0.001!");
+    std::ostringstream oss;
+    std::copy(rates_.begin(), rates_.end() - 1,
+              std::ostream_iterator<double>(oss, ","));
+    oss << *rates_.end();
+    Failwith("GTR rates do not sum to 1 +/- 0.001! rate vector: (" + oss.str() + ")");
   }
   Update();
 };

--- a/src/substitution_model.hpp
+++ b/src/substitution_model.hpp
@@ -21,6 +21,7 @@ class SubstitutionModel : public BlockModel {
 
   const EigenMatrixXd& GetQMatrix() const { return Q_; }
   const EigenVectorXd& GetFrequencies() const { return frequencies_; }
+  const size_t GetRateCount() const { return 0; }
   // We follow BEAGLE in terminology. "Inverse Eigenvectors" means the inverse
   // of the matrix containing the eigenvectors.
   const EigenMatrixXd& GetEigenvectors() const { return eigenvectors_; }
@@ -79,7 +80,7 @@ class GTRModel : public DNAModel {
     frequencies_ << 0.25, 0.25, 0.25, 0.25;
     Update();
   }
-
+  const size_t GetRateCount() const { return 6; }
   void SetParameters(const EigenVectorXdRef param_vector) override;
 
   inline const static std::string rates_key_ = "GTR rates";

--- a/src/substitution_model.hpp
+++ b/src/substitution_model.hpp
@@ -21,7 +21,7 @@ class SubstitutionModel : public BlockModel {
 
   const EigenMatrixXd& GetQMatrix() const { return Q_; }
   const EigenVectorXd& GetFrequencies() const { return frequencies_; }
-  virtual size_t GetRateCount() const { return 0; }
+  const EigenVectorXd& GetRates() const { return rates_; }
   // We follow BEAGLE in terminology. "Inverse Eigenvectors" means the inverse
   // of the matrix containing the eigenvectors.
   const EigenMatrixXd& GetEigenvectors() const { return eigenvectors_; }
@@ -37,6 +37,7 @@ class SubstitutionModel : public BlockModel {
 
  protected:
   EigenVectorXd frequencies_;
+  EigenVectorXd rates_;
   EigenMatrixXd eigenvectors_;
   EigenMatrixXd inverse_eigenvectors_;
   EigenVectorXd eigenvalues_;
@@ -80,7 +81,6 @@ class GTRModel : public DNAModel {
     frequencies_ << 0.25, 0.25, 0.25, 0.25;
     Update();
   }
-  size_t GetRateCount() const override { return 6; }
   void SetParameters(const EigenVectorXdRef param_vector) override;
 
   inline const static std::string rates_key_ = "GTR rates";
@@ -90,9 +90,6 @@ class GTRModel : public DNAModel {
   void UpdateQMatrix();
   // Update the Q matrix _and_ the eigendecomposition.
   void Update();
-
- private:
-  EigenVectorXd rates_;
 };
 
 #ifdef DOCTEST_LIBRARY_INCLUDED

--- a/src/substitution_model.hpp
+++ b/src/substitution_model.hpp
@@ -21,7 +21,7 @@ class SubstitutionModel : public BlockModel {
 
   const EigenMatrixXd& GetQMatrix() const { return Q_; }
   const EigenVectorXd& GetFrequencies() const { return frequencies_; }
-  const size_t GetRateCount() const { return 0; }
+  virtual size_t GetRateCount() const { return 0; }
   // We follow BEAGLE in terminology. "Inverse Eigenvectors" means the inverse
   // of the matrix containing the eigenvectors.
   const EigenMatrixXd& GetEigenvectors() const { return eigenvectors_; }
@@ -74,13 +74,13 @@ class JC69Model : public DNAModel {
 
 class GTRModel : public DNAModel {
  public:
-  GTRModel() : DNAModel({{rates_key_, 6}, {frequencies_key_, 4}}) {
+  explicit GTRModel() : DNAModel({{rates_key_, 6}, {frequencies_key_, 4}}) {
     rates_.resize(6);
-    rates_ << 1.0, 1.0, 1.0, 1.0, 1.0, 1.0;
+    rates_.setConstant(1.0 / 6.0);
     frequencies_ << 0.25, 0.25, 0.25, 0.25;
     Update();
   }
-  const size_t GetRateCount() const { return 6; }
+  size_t GetRateCount() const override { return 6; }
   void SetParameters(const EigenVectorXdRef param_vector) override;
 
   inline const static std::string rates_key_ = "GTR rates";
@@ -120,7 +120,7 @@ TEST_CASE("SubstitutionModel") {
   auto rates = parameter_map.at(GTRModel::rates_key_);
   // When we modify the contents of these views, that changes param_vector.
   frequencies.setConstant(0.25);
-  rates.setOnes();
+  rates.setConstant(1.0 / 6.0);
   // We can then set param_vector and go forward as before.
   gtr_model->SetParameters(param_vector);
   CheckEigenvalueEquality(jc_model->GetEigenvalues(), gtr_model->GetEigenvalues());

--- a/test/test_libsbn.py
+++ b/test/test_libsbn.py
@@ -109,7 +109,7 @@ def ds1_phylo_model_demo(inst):
     )
     inst.prepare_for_phylo_likelihood(gtr_specification, 2)
     phylo_model_param_block_map = inst.get_phylo_model_param_block_map()
-    phylo_model_param_block_map["GTR rates"][:] = np.repeat(1.0/6, 6)
+    phylo_model_param_block_map["GTR rates"][:] = np.repeat(1.0 / 6, 6)
     phylo_model_param_block_map["frequencies"][:] = 0.25
     print("\nHere's a look at phylo_model_param_block_map:")
     pprint.pprint(phylo_model_param_block_map)

--- a/test/test_libsbn.py
+++ b/test/test_libsbn.py
@@ -109,7 +109,7 @@ def ds1_phylo_model_demo(inst):
     )
     inst.prepare_for_phylo_likelihood(gtr_specification, 2)
     phylo_model_param_block_map = inst.get_phylo_model_param_block_map()
-    phylo_model_param_block_map["GTR rates"][:] = 1.0
+    phylo_model_param_block_map["GTR rates"][:] = np.repeat(1.0/6, 6)
     phylo_model_param_block_map["frequencies"][:] = 0.25
     print("\nHere's a look at phylo_model_param_block_map:")
     pprint.pprint(phylo_model_param_block_map)


### PR DESCRIPTION
## Description

The code includes calculating the derivatives of the tree likelihood wrt the parameters of the GTR model using centered finite differences.

Closes #105 


## Tests
The gradient computed by libsbn is compared to the gradient calculated using automatic differentiation in phylotorch.