### PR TITLE
331 fix test stick breaking

### DIFF
--- a/src/doctest.cpp
+++ b/src/doctest.cpp
@@ -3,7 +3,9 @@
 
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest.h"
+
 #include <string>
+
 #include "rooted_sbn_instance.hpp"
 #include "stick_breaking_transform.hpp"
 #include "taxon_name_munging.hpp"

--- a/src/doctest.cpp
+++ b/src/doctest.cpp
@@ -3,10 +3,9 @@
 
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest.h"
-
 #include <string>
-
 #include "rooted_sbn_instance.hpp"
+#include "stick_breaking_transform.hpp"
 #include "taxon_name_munging.hpp"
 #include "unrooted_sbn_instance.hpp"
 

--- a/src/stick_breaking_transform.hpp
+++ b/src/stick_breaking_transform.hpp
@@ -36,7 +36,7 @@ TEST_CASE("BreakingStickTransform") {
   StickBreakingTransform a;
   EigenVectorXd y(3);
   y << 1., 2., 3.;
-  EigenVectorXd x_expected(3);
+  EigenVectorXd x_expected(4);
   // x_expected =
   // torch.distributions.StickBreakingTransform()(torch.tensor([1., 2., 3.]))
   x_expected << 0.475367, 0.412879, 0.106454, 0.00530004;
@@ -47,7 +47,8 @@ TEST_CASE("BreakingStickTransform") {
   // log_abs_det_jacobian_expected =
   // torch.distributions.StickBreakingTransform().log_abs_det_jacobian(y,x)
   double log_abs_det_jacobian_expected = -9.108352;
-  CHECK_EQ(a.log_abs_det_jacobian(x, y), log_abs_det_jacobian_expected, 1.e-5);
+  CHECK(a.log_abs_det_jacobian(x, y) ==
+        doctest::Approx(log_abs_det_jacobian_expected).epsilon(1.e-5));
 }
 #endif  // DOCTEST_LIBRARY_INCLUDED
 

--- a/test/prep/doctest.py
+++ b/test/prep/doctest.py
@@ -18,6 +18,7 @@ preamble = """\
 #include "doctest.h"
 #include <string>
 #include "rooted_sbn_instance.hpp"
+#include "stick_breaking_transform.hpp"
 #include "taxon_name_munging.hpp"
 #include "unrooted_sbn_instance.hpp"
 
@@ -37,8 +38,8 @@ fp.write(t.write(format=9))
 fp.write('").Trees()[0];\n')
 
 traversal_translator = {
-    "preorder": "PreOrder",
-    "postorder": "PostOrder",
+    "preorder": "Preorder",
+    "postorder": "Postorder",
     "levelorder": "LevelOrder",
 }
 


### PR DESCRIPTION
## Description

 - The test case in stick_breaking_transform.hpp was not run so the header was added to test/prep/doctest.py.
 - test/prep/doctest.py was updated since it was using old method names (e.g. PostOrder instead of Postorder)

Closes #331 