### PR TITLE
327 sdag edge

### DIFF
--- a/src/bitset.hpp
+++ b/src/bitset.hpp
@@ -94,13 +94,17 @@ class Bitset {
   // These functions require the bitset to be a "PCSP bitset" with three
   // equal-sized "chunks".
   // The first chunk represents the sister clade, the second the focal clade,
-  // and the third chunk describes the children. The children are well defined
-  // relative to the cut parent: the other part of the subsplit is the cut
-  // parent setminus the child.
+  // and the third chunk describes the "child 0" clade of the child subsplit.
+  // We define "child 0" as the clade of a child subsplit that has a bitset with
+  // the smaller binary representation.
+  // The children are well defined relative to the cut parent: the other part of
+  // the subsplit, "child 1" is the cut parent setminus child 0.
+  //
   // For example, `100011001` is composed of the chunks `100`, `011` and `001`.
   // If the taxa are x0, x1, and x2 then this means the parent subsplit is (A,
-  // BC), and the child subsplit is (B,C). See the unit tests at the bottom for
-  // more examples.
+  // BC) with bitset `100|001`, and the child subsplit is (B, C) with bitset
+  // `010|001.` Child 0 is the clade `001` and child 1 is the clade `010.`
+  // See the unit tests at the bottom for more examples.
   std::string PCSPToString() const;
   bool PCSPIsValid() const;
   bool PCSPIsFake() const;

--- a/src/gp_doctest.cpp
+++ b/src/gp_doctest.cpp
@@ -585,3 +585,13 @@ TEST_CASE("GPInstance: second simplest hybrid marginal") {
   EigenVectorXd manual_log_likelihoods = ClassicalLikelihoodOf(tree_path, fasta_path);
   CheckVectorXdEquality(quartet_log_likelihoods, manual_log_likelihoods, 1e-12);
 }
+
+TEST_CASE("GPInstance: test GPCSP indexes") {
+  const std::string fasta_path = "data/7-taxon-slice-of-ds1.fasta";
+  auto inst = GPInstanceOfFiles(fasta_path, "data/simplest-hybrid-marginal.nwk");
+  auto& dag = inst.GetDAG();
+  dag.ReversePostorderIndexTraversal(
+      [&dag](size_t parent_id, bool rotated, size_t child_id, size_t gpcsp_idx) {
+        CHECK_EQ(dag.GPCSPIndexOfIds(parent_id, child_id), gpcsp_idx);
+      });
+}

--- a/src/gp_instance.cpp
+++ b/src/gp_instance.cpp
@@ -111,7 +111,7 @@ void GPInstance::ClearTreeCollectionAssociatedState() { dag_ = GPDAG(); }
 
 void GPInstance::HotStartBranchLengths() {
   if (HasEngine()) {
-    GetEngine()->HotStartBranchLengths(tree_collection_, dag_.GetGPCSPIndexer());
+    GetEngine()->HotStartBranchLengths(tree_collection_, dag_.BuildGPCSPIndexer());
   } else {
     Failwith(
         "Please load and process some trees before calling HotStartBranchLengths.");
@@ -240,8 +240,8 @@ RootedTreeCollection GPInstance::GenerateCompleteRootedTreeCollection() {
 }
 
 StringVector GPInstance::PrettyIndexer() const {
-  StringVector pretty_representation(dag_.GetGPCSPIndexer().size());
-  for (const auto &[key, idx] : dag_.GetGPCSPIndexer()) {
+  StringVector pretty_representation(dag_.BuildGPCSPIndexer().size());
+  for (const auto &[key, idx] : dag_.BuildGPCSPIndexer()) {
     if (idx < dag_.RootsplitCount()) {
       // We have decided to keep the "expanded" rootsplit representation for the time
       // being (see #273). Here we convert it to the representation used in the rest of
@@ -259,7 +259,7 @@ StringVector GPInstance::PrettyIndexer() const {
 // Convert the GP indexer to the representation used in the rest of libsbn (#273).
 BitsetSizeMap GPInstance::UnexpandedIndexer() const {
   BitsetSizeMap unexpanded_indexer;
-  for (const auto &[key, idx] : dag_.GetGPCSPIndexer()) {
+  for (const auto &[key, idx] : dag_.BuildGPCSPIndexer()) {
     if (idx < dag_.RootsplitCount()) {
       const auto classic_rootsplit_representation =
           std::min(key.SubsplitChunk(0), key.SubsplitChunk(1));
@@ -325,7 +325,7 @@ RootedTreeCollection GPInstance::CurrentlyLoadedTreesWithGPBranchLengths() {
 
 RootedTreeCollection GPInstance::CurrentlyLoadedTreesWithAPCSPStringAndGPBranchLengths(
     const std::string &pcsp_string) {
-  const BitsetSizeMap &indexer = dag_.GetGPCSPIndexer();
+  const BitsetSizeMap &indexer = dag_.BuildGPCSPIndexer();
   Bitset pcsp(pcsp_string);
   auto search = indexer.find(pcsp);
   if (search == indexer.end()) {
@@ -336,7 +336,7 @@ RootedTreeCollection GPInstance::CurrentlyLoadedTreesWithAPCSPStringAndGPBranchL
   Node::NodePtrVec topologies;
   for (const auto &tree : tree_collection_.Trees()) {
     auto indexer_representation = dag_.IndexerRepresentationOf(
-        tree.Topology(), std::numeric_limits<size_t>::max());
+        indexer, tree.Topology(), std::numeric_limits<size_t>::max());
     if (std::find(indexer_representation.begin(), indexer_representation.end(),
                   pcsp_index) != indexer_representation.end()) {
       topologies.push_back(tree.Topology()->DeepCopy());

--- a/src/tidy_subsplit_dag.hpp
+++ b/src/tidy_subsplit_dag.hpp
@@ -106,9 +106,9 @@ class TidySubsplitDAG : public SubsplitDAG {
                                         size_t node_id, bool rotated,
                                         std::unordered_set<size_t> &visited_nodes) {
     if (IsDirtyBelow(node_id, rotated)) {
-      const auto node = GetDagNode(node_id);
+      const auto node = GetDAGNode(node_id);
       for (const size_t child_id : node->GetLeafward(rotated)) {
-        if (!GetDagNode(child_id)->IsLeaf()) {
+        if (!GetDAGNode(child_id)->IsLeaf()) {
           // #288 Here we are doing true and then false (left and then right).
           DepthFirstWithTidyActionForNodeClade(action, child_id, true, visited_nodes);
           DepthFirstWithTidyActionForNodeClade(action, child_id, false, visited_nodes);
@@ -140,11 +140,11 @@ class TidySubsplitDAG : public SubsplitDAG {
     }
     // When we get to this point, the other clade is clean and we can proceed.
     action.BeforeNodeClade(node_id, rotated);
-    const auto node = GetDagNode(node_id);
+    const auto node = GetDAGNode(node_id);
     for (const size_t child_id : node->GetLeafward(rotated)) {
       if (visited_nodes.count(child_id) == 0) {
         visited_nodes.insert(child_id);
-        if (!GetDagNode(child_id)->IsLeaf()) {
+        if (!GetDAGNode(child_id)->IsLeaf()) {
           DepthFirstWithTidyActionForNode(action, child_id, visited_nodes);
         }
       }


### PR DESCRIPTION
## Description

Removed references to gpcsp_indexer_ and created dag_edges_ map (from node id pairs to gpcsp idxes) and edge_rotations_ map (from gpcsp idxes to edge rotations).

Addresses #327 

## Tests

Tests of GPCSPRotationOfIds and GPCSPIndexOfIds using the ReversePostOrderTraversal in gpdoctest.cpp

## Checklist:

<<<<<<< HEAD
* [x] The code uses informative and accurate variable and function names
* [x] The functionality is factored out into functions and methods with logical interfaces
* [x] Comments are up to date, document intent, and there are no commented-out code blocks
* [x] Commenting and/or documentation is sufficient for others to be able to understand intent and implementation
* [x] Entities are named according to our conventions
* [x] Tests are present for new functionality, and these tests fail when perturbed
* [x] `const` used where appropriate
* [x] The code uses modern C++ conventions, including range-for, `auto`, and structured bindings
* [ ] `make format` has been run _we had some difficulties running clang-format_
* [x] TODOs have been eliminated from the code
* [x] The corresponding issue number (e.g. `#278`) has been searched for in the code to find relevant notes
=======
* [x] Code follows our detailed [contribution guidelines](CONTRIBUTING.md)
* [ ] `clang-format` has been run _we had some difficulties running clang-format_
* [x] TODOs have been eliminated from the code
* [x] Comments are up to date, document intent, and there are no commented-out code blocks
>>>>>>> Add CONTRIBUTING document
