### PR TITLE
Store branch gradient in rooted gradient

### DIFF
--- a/src/fat_beagle.cpp
+++ b/src/fat_beagle.cpp
@@ -518,6 +518,8 @@ PhyloGradient FatBeagle::Gradient(const RootedTree &tree) const {
       BranchGradientInternals(tree.Topology(), branch_lengths, dQ);
 
   GradientMap gradient;
+
+  gradient["branch_lengths"] = branch_gradient;
   // Calculate substitution model parameter gradient, if needed.
   if (phylo_model_->GetSubstitutionModel()->GetRates().size() > 0) {
     FatBeagle *mutable_this = const_cast<FatBeagle *>(this);


### PR DESCRIPTION
## Description

One line patch to store the branch length gradient when computing rooted gradients.
While it's not necessarily always relevant for rooted trees, it's already computed.

## Checklist:

* [x] Code follows our detailed [contribution guidelines](CONTRIBUTING.md)
* [x] `clang-format` has been run
* [x] TODOs have been eliminated from the code
* [x] Comments are up to date, document intent, and there are no commented-out code blocks
