### PR TITLE
Improving Dot Output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ _modules
 _sources
 .RData
 .Rhistory
+.vscode
 
 # Python packaging
 build/

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Please see our detailed [contribution guidelines](CONTRIBUTING.md).
 * Anna Kooperberg ([@annakooperberg](https://github.com/annakooperberg)): refactoring the subsplit DAG
 * Sho Kiami ([@shokiami](https://github.com/shokiami)): refactoring the subsplit DAG
 * Tanvi Ganapathy ([@tanviganapathy](https://github.com/tanviganapathy)): refactoring the subsplit DAG
+* Lucy Yang ([@lucyyang01](https://github.com/lucyyang01)): subsplit DAG visualization
 * Ognian Milanov ([@ognian-](https://github.com/ognian-)): C++ wisdom, compressed files
 * Cheng Zhang ([@zcrabbit](https://github.com/zcrabbit)): concept, design, algorithms
 * Christiaan Swanepoel ([@christiaanjs](https://github.com/christiaanjs)): design

--- a/environment.yml
+++ b/environment.yml
@@ -27,3 +27,4 @@ dependencies:
       - sphinx-rtd-theme
       - tensorflow
       - tensorflow-probability
+      - graphviz

--- a/src/gp_doctest.cpp
+++ b/src/gp_doctest.cpp
@@ -600,6 +600,7 @@ TEST_CASE("GPInstance: test GPCSP indexes") {
 TEST_CASE("GPInstance: test rootsplits") {
   const std::string fasta_path = "data/7-taxon-slice-of-ds1.fasta";
   auto inst = GPInstanceOfFiles(fasta_path, "data/simplest-hybrid-marginal.nwk");
+  inst.SubsplitDAGToDot("_ignore/outtest.dot", true);
   auto& dag = inst.GetDAG();
   for (const auto& rootsplit_id : dag.RootsplitIds()) {
     const auto rootsplit_node = dag.GetDAGNode(rootsplit_id);

--- a/src/subsplit_dag.cpp
+++ b/src/subsplit_dag.cpp
@@ -89,7 +89,12 @@ std::string SubsplitDAG::ToDot(bool show_index_labels) const {
       true, SubsplitDAGTraversalAction(
                 // BeforeNode
                 [this, &string_stream, &show_index_labels](size_t node_id) {
-                  auto bs = GetDAGNode(node_id)->GetBitset();
+                  const auto &node = GetDAGNode(node_id);
+                  if (node->IsDAGRootNode()) {
+                    string_stream << node_id << " [label=\"<f0>&rho;\"]\n";
+                    return;
+                  }
+                  auto bs = node->GetBitset();
                   string_stream << node_id << " [label=\"<f0>"
                                 << bs.SubsplitChunk(0).ToIndexSetString() << "|<f1>";
                   if (show_index_labels) {
@@ -116,9 +121,18 @@ std::string SubsplitDAG::ToDot(bool show_index_labels) const {
                   if (show_index_labels) {
                     string_stream << " [label=\"" << GPCSPIndexOfIds(node_id, child_id);
                     if (rotated) {
-                      string_stream << "\", color=1, fontcolor=1]";
+                      string_stream << "\", color=1, fontcolor=1";
                     } else {
-                      string_stream << "\", color=3, fontcolor=3]";
+                      string_stream << "\", color=3, fontcolor=3";
+                    }
+                    if (GetDAGNode(node_id)->IsDAGRootNode()) {
+                      string_stream << ",style=dashed]";
+                    } else {
+                      string_stream << "]";
+                    }
+                  } else {
+                    if (GetDAGNode(node_id)->IsDAGRootNode()) {
+                      string_stream << "[style=dashed]";
                     }
                   }
                   string_stream << "\n";


### PR DESCRIPTION
## Description

* Dot output labels DAG root with rho, and edges from the DAG root are dashed.
* Created an additional command for the vip cli called dag-to-dot, which takes a newick, fasta, and output path and outputs a dot and svg file.

Closes #347


## Checklist:

* [x] Code follows our detailed [contribution guidelines](CONTRIBUTING.md)
* [x] `clang-format` has been run
* [x] TODOs have been eliminated from the code
* [x] Comments are up to date, document intent, and there are no commented-out code blocks
